### PR TITLE
added markdown and block tags

### DIFF
--- a/nbloader.py
+++ b/nbloader.py
@@ -1,6 +1,8 @@
 import os
 import io
 
+import mistune
+
 from nbformat import reader, converter, current_nbformat
 from IPython.core.interactiveshell import InteractiveShell
 from IPython import get_ipython
@@ -10,39 +12,55 @@ class NotImplementedError(Exception):
     pass
 
 class Notebook(object):
-    
-    def __init__(self, nb_path, ns=None):
+
+    def __init__(self, nb_path, ns=None, tag_md=True, nb_dir=None):
         self.nb_path = nb_path
-        if ns is None:
-            self.ns = dict()
-        else:
-            self.ns = ns
+
+        # markdown
+        self.tag_md = tag_md
+        if tag_md:
+            self.md_parser = mistune.Markdown()
+
+        if nb_dir is None:
+            nb_dir = os.path.dirname(self.nb_path)
+        self.nb_dir = nb_dir
+
+        self.restart(ns)
+        self.shell = InteractiveShell.instance()
+        self.refresh()
+        self.run_tag('__init__', strict=False)
+
+    def restart(self, ns=None):
+        self.ns = ns or dict()
         if 'get_ipython' not in self.ns:
             # not sure if thats really needed
             self.ns['get_ipython'] = get_ipython
 
-        self.shell = InteractiveShell.instance()        
-        self.refresh()
-        self.run_tag('__init__', strict=False)
-        
-    def restart(self):
-        self.ns = dict()
-        if 'get_ipython' not in self.ns:
-            # not sure if thats really needed
-            self.ns['get_ipython'] = get_ipython
-        
     def refresh(self):
         self.cells = []
-        
+        self.md_tags = []
+        self.block_tag = None
+
         with io.open(self.nb_path, 'r', encoding='utf-8') as f:
             notebook = reader.read(f)
 
         # convert to current notebook version
         notebook = converter.convert(notebook, current_nbformat)
-        
+
         compiler = CachingCompiler()
         for i, cell in enumerate(notebook.cells):
-            if cell.cell_type == 'code':
+            if cell.cell_type == 'markdown' and self.tag_md:
+                tokens = self.md_parser.block(cell.source)
+                for tok in tokens:
+                    if tok['type'] == 'heading':
+                        new_level, tag = tok['level'], tok['text']
+                        self.md_tags = [
+                            (lvl, tag) for lvl, tag in self.md_tags
+                            if lvl < new_level
+                        ]
+                        self.md_tags.append((new_level, tag))
+
+            elif cell.cell_type == 'code':
                 # translate all magic % commands to code
                 source = self.shell.input_transformer_manager.transform_cell(cell.source)
                 # need to use this cell_name so it gives a nice debug information from the notebook
@@ -54,68 +72,75 @@ class Notebook(object):
 
     def _run(self, cells):
         cwd = os.getcwd()
-        nb_dirname = os.path.dirname(self.nb_path)
-        if nb_dirname:
-            os.chdir(nb_dirname)
-        for cell in cells:
-            try:
+        if self.nb_dir:
+            os.chdir(self.nb_dir)
+
+        try:
+            for cell in cells:
                 exec(cell['code'], self.ns)
-            except Exception as e:
-                raise e
-                os.chdir(cwd)
-        os.chdir(cwd)
-        
+        finally:
+            os.chdir(cwd)
+
     def run_all(self, blacklist=None):
         cells = self.cells[:]
-        if blacklist is not None:
-            if type(blacklist) == str:
+        if blacklist:
+            if isinstance(blacklist, str):
                 blacklist = [blacklist]
-            filtered_cells = []
-            for cell in cells:
-                is_blacklisted = False
-                for tag in blacklist:
-                    if tag in cell['tags']:
-                        is_blacklisted = True
-                        break
-                if not is_blacklisted:
-                    filtered_cells.append(cell)
-            cells = filtered_cells
+
+            cells = [
+                cell for cell in cells
+                if not any(tag in cell['tags'] for tag in blacklist)
+            ]
 
         self._run(cells)
         return self
-        
+
     def run_cells(self):
         raise NotImplementedError()
-        
+
     def _cell_tags(self, cell):
-        if cell.cell_type != 'code':
-            return [None]
-        if 'tags' not in cell.metadata:
-            tags = []
-        else:
-            tags = cell.metadata['tags']
-        if cell.source[0] == '#':
-            first_line = cell.source.split('\n', 1)[0]
-            first_line = first_line.strip('#').strip()
-            tags += first_line.split()
-        if tags == []:
-            tags = [None]
-        return tags
+        tags = []
+        if cell.cell_type == 'code':
+            tags = cell.metadata.get('tags', [])
+
+            for level, tag in self.md_tags:
+                # can access either through heading text
+                # or with level specified using markdown syntax
+                tags.append(tag)
+                tags.append('#' * level + ' ' + tag)
+
+            if self.block_tag:
+                tags.append(self.block_tag)
+
+            if cell.source and cell.source[0] == '#':
+                first_line = cell.source.split('\n', 1)[0]
+
+                if first_line.startswith('##block '):
+                    first_line = first_line[8:].strip()
+                    self.block_tag = first_line
+                    tags.append(first_line)
+
+                elif first_line.startswith('##lastblock'):
+                    self.block_tag = None
+
+                else:
+                    first_line = first_line.strip('#').strip()
+                    tags.extend(first_line.split())
+
+        return tags or [None]
 
     def run_tag(self, tag, strict=True):
-        cells = []
-        for cell in self.cells:
-            if tag in cell['tags']:
-                cells.append(cell)
-        if len(cells):
+        cells = [cell for cell in self.cells if tag in cell['tags']]
+
+        if cells:
             self._run(cells)
         else:
-            assert not strict, 'Tag "%s" found' % tag
+            assert not strict, 'Tag "{}" found'.format(tag)
         return self
 
     def __del__(self):
         self.run_tag('__del__', strict=False)
-        
+
     def __getstate__(self):
         return (self.nb_path, self.ns)
 

--- a/tutorial/main.ipynb
+++ b/tutorial/main.ipynb
@@ -2,46 +2,52 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after compile before __init__\n",
+      "I am inside loaded_notebook!\n",
+      "in __init__\n",
+      "I should still be in __init__\n",
+      "I am inside loaded_notebook!\n",
+      "in __init__\n",
+      "I should still be in __init__\n",
+      "Ran Data (heading 1)\n",
+      "Ran Data 1 (heading 2)\n",
+      "Ran Data 2 (heading 2)\n",
+      "Ran Plot 1 (heading 2)\n",
+      "Ran Plot 2 (heading 2)\n",
+      "after compile before __init__\n",
+      "I am inside loaded_notebook!\n",
+      "in __init__\n",
+      "I should still be in __init__\n"
+     ]
+    }
+   ],
    "source": [
     "from nbloader import Notebook\n",
     "\n",
-    "test = Notebook('test_notebook.ipynb')\n",
+    "notebook = Notebook('test.ipynb')\n",
     "# tag __init__ is executed\n",
-    "assert test.ns['a'] == 5\n",
+    "assert notebook.ns['a'] == 5\n",
     "\n",
-    "test.run_all()\n",
-    "assert test.ns['a'] == 6\n",
-    "assert test.ns['b'] == 10\n",
+    "notebook.run_all()\n",
+    "assert notebook.ns['a'] == 6\n",
+    "assert notebook.ns['b'] == 10\n",
     "\n",
-    "test = Notebook('test_notebook.ipynb')\n",
+    "notebook = Notebook('test.ipynb')\n",
     "try:\n",
-    "    test.ns['b']\n",
+    "    notebook.ns['b']\n",
     "except KeyError:\n",
     "    assert True\n",
     "else:\n",
     "    assert False\n",
     "\n",
-    "assert test.run_tag('create_b').ns['b'] == 10"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    a\n",
-    "except NameError:\n",
-    "    assert True\n",
-    "else:\n",
-    "    assert False\n",
-    "test = Notebook('test_notebook.ipynb', ns=globals())\n",
-    "assert a == 5\n",
-    "del a"
+    "assert notebook.run_tag('create_b').ns['b'] == 10"
    ]
   },
   {
@@ -53,6 +59,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "after compile before __init__\n",
+      "I am inside loaded_notebook!\n",
+      "in __init__\n",
+      "I should still be in __init__\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    a\n",
+    "except NameError:\n",
+    "    assert True\n",
+    "else:\n",
+    "    assert False\n",
+    "notebook = Notebook('test.ipynb', ns=globals())\n",
+    "assert a == 5\n",
+    "del a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after compile before __init__\n",
+      "I am inside loaded_notebook!\n",
+      "in __init__\n",
+      "I should still be in __init__\n",
       "6\n",
       "7\n",
       "1\n"
@@ -60,16 +98,132 @@
     }
    ],
    "source": [
-    "from nbloader import Notebook\n",
-    "notebook = Notebook('test_notebook.ipynb')\n",
+    "notebook = Notebook('test.ipynb')\n",
     "notebook.run_tag('add_one')\n",
     "print(notebook.ns['a']) # 6\n",
+    "assert notebook.ns['a'] == 6\n",
+    "\n",
     "notebook.run_tag('add_one')\n",
     "print(notebook.ns['a']) # 7\n",
+    "assert notebook.ns['a'] == 7\n",
+    "\n",
     "notebook.ns['a'] = 0\n",
     "notebook.run_tag('add_one')\n",
-    "print(notebook.ns['a']) # 1"
+    "print(notebook.ns['a']) # 1\n",
+    "assert notebook.ns['a'] == 1"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['This is a test notebook', '# This is a test notebook', '__init__']\n",
+      "['This is a test notebook', '# This is a test notebook', 'create_b']\n",
+      "['This is a test notebook', '# This is a test notebook', 'add_one']\n",
+      "['This is a test notebook', '# This is a test notebook', '__init__']\n",
+      "['This is a test notebook', '# This is a test notebook', '__init__']\n",
+      "['This is a test notebook', '# This is a test notebook', '__init__']\n",
+      "['This is a test notebook', '# This is a test notebook']\n",
+      "['Data', '# Data']\n",
+      "['Data', '# Data', 'Data 1', '## Data 1']\n",
+      "['Data', '# Data', 'Data 1', '## Data 1']\n",
+      "['Data', '# Data', 'Data 2', '## Data 2']\n",
+      "['Data', '# Data', 'Data 2', '## Data 2']\n",
+      "['Plot', '# Plot', 'Plot 1', '## Plot 1']\n",
+      "['Plot', '# Plot', 'Plot 1', '## Plot 1']\n",
+      "['Plot', '# Plot', 'Plot 2', '## Plot 2']\n",
+      "['Plot', '# Plot', 'Plot 2', '## Plot 2']\n",
+      "['Plot', '# Plot', 'Plot 2', '## Plot 2']\n"
+     ]
+    }
+   ],
+   "source": [
+    "for c in notebook.cells:\n",
+    "    print(c['tags'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ran Data (heading 1)\n",
+      "Ran Data 1 (heading 2)\n",
+      "Ran Data 2 (heading 2)\n",
+      "Ran Data (heading 1)\n",
+      "Ran Data 1 (heading 2)\n",
+      "Ran Data 2 (heading 2)\n",
+      "-----data h1 done-----\n",
+      "Ran Data 1 (heading 2)\n",
+      "Ran Data 1 (heading 2)\n",
+      "-----data 1 h2 done-----\n",
+      "Ran Data 2 (heading 2)\n",
+      "Ran Data 2 (heading 2)\n",
+      "-----data 2 h2 done-----\n",
+      "Ran Plot 1 (heading 2)\n",
+      "Ran Plot 2 (heading 2)\n",
+      "Ran Plot 1 (heading 2)\n",
+      "Ran Plot 2 (heading 2)\n",
+      "-----plot h1 done-----\n",
+      "Ran Plot 1 (heading 2)\n",
+      "Ran Plot 1 (heading 2)\n",
+      "-----plot 1 h2 done-----\n",
+      "Ran Plot 2 (heading 2)\n",
+      "Ran Plot 2 (heading 2)\n",
+      "-----plot 2 h2 done-----\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl81PW97/HXd2Yyk42wh0D2QAgEkkBAFlFkUUAwggqYsLWnh4NdqHpOeWir3ntt75XaHtvb9np6Wq+eW4EkrIKgLIJWcUFkEUJYAlkhG3sCySSZmeR7/5hoAdkzk1+S+TwfDx8k8/vx+70zhvnMb+b3e4/SWiOEEML3mIwOIIQQwhgyAIQQwkfJABBCCB8lA0AIIXyUDAAhhPBRMgCEEMJHyQAQQggfJQNACCF8lAwAIYTwURajA9xMjx49dExMjNExhBCi3di3b985rXXP21m3TQ+AmJgY9u7da3QMIYRoN5RSJbe7rrwEJIQQPkoGgBBC+CgZAEII4aNkAAghhI+SASCEED5KBoAQQvgoGQBCCOGj2vR1AEII4UtKyipYvTyT+nPn+W+v/drr+5MBIIQQBsorLGZD1koaCwqx2U9jopEAUxDVNZfpHNzJq/uWASCEEK0s51ge72WvRpWUYK07g4UmzKZA7N1iCB2eyvy5TxLo7+/1HDIAhBCiFez++iA71q7HXHoSv/qz2NBoczC1PfsSOXokc2c+jtVmbdVMMgCEEMJL/v75Lj7f+D5+5aVYHOfwB5rMIdT26k+/sWOYPeNRLBbjHoZlAAghhAdt+ehj9m7ehq2yDLPzAgFAo6ULtX0GMXjiOB6d8pChD/pXahsphBCinXK5XGzcup3cDz/G/0wZZlcVgUCjXzfskUkMe3gSUyeONzrmdckAEEKIO+RyuVi94T3yd35GwLlyTI2XCAJc1h7UxQxhzKPTGD9mtNExb0kGgBBC3AZHg4PMte9watduAi9UoBprCELh9O+JI7Y/D858jJFDU4yOeUdkAAghxA3Y6+tZnrmKM3v3E1BVgWqyE4QJR0AoOmYwj6TPInlAgtEx75oMACGEuEJ1zWVWLM/m4sFD+FdVonQdgZhpCOyFuW8qM+akkxAXY3RMj5ABIITweeerqlj+diY1uYcJuHwadAMBWKgPDsPavx+z580lOry30TE9TgaAEMInVZw5Q9bbWdTn5eFfUwnaSYCyUh/ci8DEgWTMn0tYz+5Gx/QqGQBCCJ9RePIUa1aspDE/H1vtacCFTflTF9KHkKTBzF8wl66dQ4yO2WpaPACUUgnAqituigP+u9b6D1esMw54FyhqvukdrfWvWrpvIYS4lSMn8nk3azUUFWGtO93cuxOAvWsUPVKHMH9uOsFBgUbHNESLB4DWOg8YAqCUMgNlwPrrrPqp1vqRlu5PCCFuZV/uYbauXoe5pAS/+rNYaUKbgrB3j6P3yGEsSH+y1Xt32iJPvwQ0ESjQWpd4eLtCCHFTX+zdz0fr3sWv7CSWhnP4o9HmTtSG9iNmzGjmzHyszVQwtBWevjfSgewbLButlDoIlANLtNaHPbxvIYSP2bHzc3a9txlrRSkWx3kCgCZLZ+xhA4gfdz8z06bKg/5NeOyeUUpZgUeBX1xn8X4gWmtdo5SaCmwA4m+wnUXAIoCoqChPxRNCdBCbPtjBgW07sJ0uw+y82Ny70xV7xGBSHprIo1MeMjpiu6G01p7ZkFLTgZ9orSfdxrrFwHCt9bmbrTd8+HC9d+9ej+QTQrRPLpeLd97fSt7fP8H/bDkmV7X7dmt3HGHhjJw2lUnj7jM4ZduhlNqntR5+O+t68tgogxu8/KOUCgNOa621UmoE7g+jP+/BfQshOhCXy8XKdRso+mwX/ufLMTVeJhBw2XrSEJXK2BlpjB15j9Ex2z2PDAClVCDwEPDUFbf9EEBr/RdgJvAjpZQLqAPStacOPYQQHYKjwcHylWso372HgIuVqKYaAlE4/UNxxA3goVmPMSIl2eiYHYpHBoDW2g50v+a2v1zx9evA657YlxCi46iptbM8cyXn9h8goLoS1WQnsLlsjdgk0tJnMTihv9ExOyx5e1wI0aouVl9i+fIsLh3Kxb+6EqXr3WVrQb0w9x3GE3PT6RcTbXRMnyADQAjhdZVnz5O9PBP7kWPNvTsOAvCjPrgXtoT+ZCyYQ3hYmNExfY4MACGEV5SUVbB6RTaO48fxrzkNOPFXVuo6hRE0KJG5C+YQ2q2b0TF9mgwAIYTH5BeXsC5zJY35BdjspzHR6C5b6xJO5+Qk5s3L8KmytbZOBoAQokVy846zKXsNFBdhrTvTXLYWiL1bND1Th7JgfgaB/v5GxxTXIQNACHHHvjqYw/Y16zGf+qZsTaNNwdh79CV81D3Mmz1TytbaARkAQojbsnP3Hj5ZvxFr2SksjnP4A03mEOyh/Ykbey9PPjZdenfaGfm/JYS4oW0f7+Sr97diqyjD7DxPINBk6UJtn0QGTXiA6Q9Plgf9dkz+zwkhrrJh81ZydnyE/5mKK8rWumGPTCJ18kNMe2iC0RGFh8gAEMLHuVwu1mx8nxOffErAuQpMrmqCAJe1B3UxQxidNpWJ991rdEzhBTIAhPBBLpeLzFXrOLlrNwEXKlCNlwlC4bT1pCFmOBMfn8HoYUOMjim8TAaAED7CXl9P5srVVH61r7lsrdbdu+PfE90vkanpMxmSONDomKIVyQAQogOrqbXz9vIsLhw42Fy2Vufu3QkMRcUNZUbGbAb2izM6pjCIDAAhOpjzVVWsWJ7N5ZxcAi5Xgm4gEAv1wb2wxsczc14GsRHhRscUbYAMACE6gIozZ8halkX9sTx37452EKCs1Af3wn9AAnMWzKF3aKjRMUUbIwNAiHaqqLSMNcuzcZ04ga32NODCX9moC+lNp6TBzJufQfcuXYyOKdowGQBCtCNH8wvZkL0aXViAzX4GM42YTAHYu0bSfegQFszLIDgo0OiYrcbpdFJaWkp9fb3RUVqdv78/ERER+Pn53fU2ZAAI0cYdOHKUzSvXokqKsdafxUoT2hSEvXsMYSOGMTd9ts+WrZWWltKpUydiYmJQShkdp9VorTl//jylpaXExsbe9XZkAAjRBu3ad4AP39mA5VQJfg3nsKHR5k7UhvYj+t5RzJ31uFQwAPX19T734A+glKJ79+6cPXu2Rdvx2G+QUqoYuAw0Ai6t9fBrlivgj8BUwA58X2u931P7F6K9+/CzL9i1aTN+5aVYHOcIAJosnakNSyD+gfuZ9eg0edC/Dl978P+GJ35uT/82jddan7vBsoeB+Ob/RgL/2fynED7r/e0fsW/rdvxPl2F2XiAAaPTrij18EMmTJjB9ymSjI4q7NG7cOF577TWGDx9+w3WWLl3KCy+8cN1lL774IsuWLePixYvU1NR4JWNrPp2YDizTWmvgS6VUF6VUb611RStmEMJQLpeLd7ds4/BHnxBwphyTq4ogoNGvO/aoZEZMm8LkcWONjilayc0GQFpaGosXLyY+Pt5r+/fkANDAB0opDfxVa/3GNcvDgVNXfF/afNtVA0AptQhYBBAVFeXBeEIYw+VysWr9uxTu/AL/8xWYGi+5y9ZsPamPHMoDjz3K2JH3GB1T3IXi4mKmTJnCyJEj+frrr+nfvz/Lli0jMPDqM7Gys7NZunQpWmumTZvGb37zG37+859TV1fHkCFDGDRoEJmZmVf9nVGjRnk9vycHwBitdblSKhTYrpQ6prXeecXy671gpb9zg3twvAEwfPjw7ywXoj1wNDhYsXotZV9+RcCFSlRTDYEonP6hOOISeGjWY4xISTY6Zofyy02HOVJ+yaPbTOwTwv9IG3TTdfLy8njrrbcYM2YMP/jBD/jzn//MkiVLvl1eXl7O888/z759++jatSuTJk1iw4YNvPrqq7z++uscOHDAo5nvhMcGgNa6vPnPM0qp9cAI4MoBUApEXvF9BFDuqf0LYTR7fT3Llmdzdv/XBFRVoprs7rK1gFCISSItYxaDE/obHVN4WGRkJGPGjAFg3rx5/OlPf7pqAOzZs4dx48bRs2dPAObOncvOnTuZMWOGIXmv5JEBoJQKAkxa68vNX08CfnXNahuBxUqplbjf/K2W1/9Fe1ddc5llb2dRnXMI/+pKlK53l60F9cLcdxhPzE2nX0y00TF9wq2eqXvLtWfjXPu9+23PtslTRwC9gPXNP7gFyNJab1VK/RBAa/0XYDPuU0DzcZ8G+k8e2rcQrerMhQtkvp1J7ZGjzWVrDgLwc5et9e/P7HkZRIf3NjqmaCUnT55k165djB49muzsbO67776rlo8cOZJnnnmGc+fO0bVrV7Kzs/npT38KgJ+fH06ns0VX87aERwaA1roQSLnO7X+54msN/MQT+xOitZVVVpK9LIuGvOPusjWcBCgrdZ3CCEocyNzvzSW0WzejYwoDDBw4kLfffpunnnqK+Ph4fvSjH121vHfv3vz6179m/PjxaK2ZOnUq06dPB2DRokUkJyeTmpr6nTeBn3vuObKysrDb7URERLBw4UJefvllj2ZXbfnwZPjw4Xrv3r1GxxA+Kr+4hHWZK2ksKMBWewZwoZU/9Z3D6JycxLx5GXTtHGJ0TJ929OhRBg407kNsiouLeeSRR8jNzTVk/9f7+ZVS+669EPdG5LJCIa6Qm3ecTSvXQFER1rozWGjCbArE3i2KnqlDmDcn3afK1kTHJgNA+Lw9Obl8sHod5lMn8as/gxWNNgVj7xFH+MgRzHtyJlab1eiYog2KiYkx7Nm/J8gAED5p5+49fLJ+I9byUiwNZ/EHmswh2EP7E3vfaNKfmCG9O6LDk99w4TM++Pgzdr+/GWtlGRbHeQKBJksX7L0HMmDCOB6bOlke9IVPkd920aG9u3UbOR98hO1MOWbnRQJpLluLGMyQyQ+SNulBoyMKYRgZAKJDcblcrN20mRMff4r/uXJMrmoCAZe1O/boFEY/MpUHx44xOqYQbYIMANHuuVwuMte8Q8kXXxJ4vgLVeJlAFC5bDxqihzHh8encOzzV6JjCx7SkDtputzNr1iwKCgowm82kpaXx6quvejyjDADRLjkaHCxbuYqK3fsIuFiBaqolCBNO/5409hvIlNlPMGywMdUAQtyum9VBL1myhPHjx+NwOJg4cSJbtmzh4Ycf9uj+ZQCIdqOm1s6yFdmc//oAAdWVqKY6AjHjCAyF2CFMz5hFYnw/o2MKH+KtOujAwEDGjx8PgNVqJTU1ldLSUo/nlwEg2rSL1ZdYviyTS4dy8b90urlszeIuW+vXj1nz0omLirz1hkTHt+XnUHnIs9sMS4KHb/7Si7froKuqqti0aRPPPPOMR36kK8kAEG1O5dnzZC3LpO7oUXfvjnYQoPyoDw7DPyGBOd+bQ+/QUKNjCgF4tw7a5XKRkZHB008/TVxcnMezywAQbUJJWQWrl2fiOHGiuWzNhb+yUdepN52SEpm3YC7du3QxOqZoy27xTN1bvFkHvWjRIuLj43n22Wfvehs3IwNAGCavsJgNWStpLCjEZj+NiUZsKoC6rpF0TUli3vwMOgd3MjqmEDflrTrol156ierqat58802vZZcBIFpVzrE83stejSopuaJsLQh79xh6DR/GvDmzCfT3NzqmELfNG3XQpaWlvPLKKwwYMIDUVPcpzIsXL2bhwoUezS510MLrdn99kB1r12MuPYlf/VlAo83B2Lv1Jnr0KDJmPiZla+KuSB201EGLNujvn+/i843v41deisVx7tuytdpeCfQbex+zZzwivTtCGEz+BQqP2fLRx+zdvA1bZRlm5wUCcPfu1IYnkvzgBGZMnWJ0RCE8yufroJVSkcAyIAxoAt7QWv/xmnXGAe8CRc03vaO1vvZD40U743K52Lh1O7kffoz/mTLMrqrmsrVu2COTGD51Mg9PGGdwSiHEjXjiCMAF/ExrvV8p1QnYp5TarrU+cs16n2qtH/HA/oSBXC4XqzdsJH/n5wScq8DUeIkgwGXtQV3sUO6fnsYDo0cYHVMIcRtaPAC01hVARfPXl5VSR4Fw4NoBINopR4ODzLXvcGrXbgIvVKAaawhC4fTviSMugQefmMHIoSlGxxRC3CGPvgeglIoBhgK7r7N4tFLqIFAOLNFaH/bkvoVn2evrWZ65ijN79xNQVYFqshOECUdAKDpmMI+kzyJ5QILRMYUQLeCxAaCUCgbWAc9qrS9ds3g/EK21rlFKTQU2APE32M4iYBFAVFSUp+KJ21Bdc5kVy7O5eCAH/+rTKO0uW2sI7IW53zBmZDxJQlyM0TGFaBdaUgcN8OKLL7Js2TIuXrxITU2NVzJ6ZAAopfxwP/hnaq3fuXb5lQNBa71ZKfVnpVQPrfW566z7BvAGuK8D8EQ+cWPnq6pY/nYmNbmHCbh8GnQDAVioDw7D2r8/s+dlEB3e2+iYQnRINxsAaWlpLF68mPj46z5X9ghPnAWkgLeAo1rr399gnTDgtNZaK6VGACbgfEv3Le5OxZkzZP0tk/q8PPxrT4N2EqCs1AeHEZg4gIz5cwnr2d3omEK0ed6qgwYYNWqU1/N74ghgDDAfOKSU+qbX9AUgCkBr/RdgJvAjpZQLqAPSdVu+BLkDKjx5ijUrVtKYn4+t1l22ZlP+1HUOJyRpMPPnz6Fr5xCjYwpx137z1W84duGYR7c5oNsAnh/x/E3X8XYdtDd54iygzwB1i3VeB15v6b7EnTlyIp93s1ZDURHWutPNvTuB2LtG0SN1CPPnphMcFHjrDQkhbsibddDeJlcCdzB7cnL5YM07mE+W4Fd/FitNaFMQ9u5x9Bl5D/PTZ0nvjuiQbvVM3Vu8WQftbTIAOoAv9u7no3Xv4ld2EkvDOfzRNJk7YQ+NJ/a+0aQ/MUN6d4TwEm/VQbcGeVRop3bs/Jxd723GWlGKxXGeAKDJ0hl77wEkjH+Ax6dNkQd9IVqBN+qgAZ577jmysrKw2+1ERESwcOFCXn75ZY9mlzrodmTTBzs4sG0HttNlmJ0XAXfZWkOvcIZMfpC0SQ8anFCI1iV10FIH3WG5XC7eeX8reX//BP+z5Zhc1QQCLmt37NEpjJz6MJPG3XfL7QghxPXIAGhjXC4XK9dtoOizXfifL8fUeJlAFC5bDxqihjHusTTuG3Fbw10I4WU+XwctWs7R4GD5yjWU795DwMVKVFMNgSic/qE4+g5k0qzHuSd5sNExhRAdjAwAg9TU2lmRtZKz+w8QUFWJarITiAlHQC+ITWb6nNkkxvczOqYQogOTAdCKLlZfYvnyLC4dysW/uhKl6wnEQkNQKOZ+w5k1L4O4qEijYwohfIQMAC+rPHue7OWZ2I8cw7+mErSDAOVHfVAv/BMSSF+QQXhYmNExhRA+SAaAF5SUVbB6RTaO48fxrzkNOPFXNuo6hRE0KJG5C+YQ2q2b0TGFEF7Ukjpou93OrFmzKCgowGw2k5aWxquvvurxjDIAPCS/uIR1mStpzC/AZj+NiUZ32VqXcLqkJDN/QQadgzsZHVMI0YbcrA56yZIljB8/HofDwcSJE9myZQsPP/ywR/cvA6AFcvOOsyl7DRQXYa0784+ytW7R9EwdyoL5GQT6+xsdUwjhJd6qgw4MDGT8+PEAWK1WUlNTKS0t9Xh+GQB36KuDOWxfsx7zqW/K1jTaFIy9R1/CR93DvNkzpWxNCANULl1Kw1HP1kHbBg4g7AbP0L/h7TroqqoqNm3axDPPPOORn+lKMgBuwye7vuLTdzfhV3YKi+Mc/kCTOYTaXv3pN3YMs2c8Kr07Qvgob9ZBu1wuMjIyePrpp4mLi/N4dnnUuoFtH+/kq/e3Yqsow+z8pmytC7V9Ehk8cTyPTnlIHvSFaENu9UzdW7xZB71o0SLi4+N59tln73obNyOPYFfYsHkrOTs+wv9MBWbnRQKBRr9u2COTGPbwJKZOHG90RCFEG+OtOuiXXnqJ6upq3nzzTa9l9+kB4HK5WL3hPfJ3fkbAuQpMjdUEAS5rD+pihjDm0WmMHzPa6JhCiDbMG3XQpaWlvPLKKwwYMIDU1FQAFi9ezMKFCz2a3SN10EqpKcAfATPwptb61WuW24BlwDDcHwb/pNa6+Fbb9UYdtMvlInPVOk7u2k3AhQpU42VA4bT1xBUZxcTHZzB62BCP7lMI4R1SB21wHbRSygz8B/AQUArsUUpt1FofuWK1fwYuaq37KaXSgd8AT7Z037fLXl/PiqzVnN67r7lsrba5dycUHZ3I1CdnMiTRuF8iIYQwgideAhoB5GutCwGUUiuB6cCVA2A68HLz12uB15VSSnvx02iqay6zYsUqLh446O7daaojEDMNgb0w9x3KjDnpJMTFeGv3QggfIHXQEA6cuuL7UmDkjdbRWruUUtVAd+CcB/Z/lbLKSt77w3LMzga4UESA/Tz1wb2wxsczc14GsRHhnt6lEEK0S54YAOo6t137zP521nGvqNQiYBFAVFTUHYcJcTTQYGnigr8LOkXSxdWPpCbN4H7RRIX1uuPtCSFER+WJAVAKXNlhHAGU32CdUqWUBegMXLjexrTWbwBvgPtN4DsN0ykqmh+//DMufLWbnK2fkt+k+drPwf7cw4QcPEGsCwYPiiYu/UnMch6/EMKHeeIRcA8Qr5SKBcqAdGDONetsBL4H7AJmAh958/V/i8VC6L1jePDeMTwIXDhwgIPvbiO/sYkcq4OD+ScI+uVviHUqEuPDSJg3D7PUNwghfIyppRvQWruAxcA24CiwWmt9WCn1K6XUo82rvQV0V0rlA/8G/Lyl+70T3YYMYfz/eJ5/WfoL/jVjFhMtQXR3mThqc7L61Elee+W3rPr5UnL+/FdcNbWtGU0I0UGNGzeOW53GvnTp0hsue/HFF4mMjCQ4ONjT0b7lkesAvMUb1wFcqaaokJyVGzh+qYFSqxOXasLWZCHaYWJg7y4M/v4c/Dp38dr+hRAtY/R1ADdzO58HEBwcTE1NzXWXffnll0RHRxMfH3/DdQy/DqA9C46N495f/Bv3AnUV5eSsWM3x83aKbI0cv3iGLb//P0Q1mEnoGUTS/HT8Q+VNZCHEP3irDhpg1KhRXs/v00cAN9Jw4Ty5y7LJq7xEibWJBpMLizYR2eBH/y42UubNIjBCPrtXCKNd+Qz409XHOXfq+s+U71aPyGDun93/hsuLi4uJjY3ls88++7YOOjExkSVLlnx7BNCnTx9GjRp1VR30008/zYwZM256BPCNm60jRwBeYOvWnWHPLmYY4Lx0iaMrsjhy8gLF1kaK6i+x4//+F+EOK/2D/UiZnUan+ASjIwshDOLNOmhvkwFwC34hIST/+IckA666OvJWZHGk4DTF1iZ2OGv4aMVK+jit9PM3k/LYZLompRgdWQifdLNn6t7kzTpob5MBcAcsAQEM+pd/ZhDQ2OAgf9UqDh89SZFF83GTnU/WricsezP9rIqUaRPocc8IoyMLIbzMW3XQrUEGwF0y26wkLJhPAtDoclG8bh25BwsoNGk+pYFP39tMrw0f0tcEKQ/eS68HHjA6shDCC7xRBw3w3HPPkZWVhd1uJyIigoULF/Lyyy97NLu8CewFJRs3cujLXApNiguWBgB6OG30VZqk+1OJmDzF4IRCdAxGnwbq83XQ4ruiH32U6Efd18CVfbCNnJ37KAB2Wxzs3vUlXT/9mr5NmqSRiURMe0QqKYQQhpBHHi8LnzSZ8EmTATj96U4Obv+cAg17/Rzs/foAnfcecfcTJccRO2umDAMh2hGpgxa3rdf9Y5l0/1gAzu35ipz3PyK/UXPQ2sCBvGME//K3xLk0iQlRxGc8Kf1EQgivkgFgkB73jGDCPSOYAFQdyuHg+m2caHCRa3WSU1xA4Cv/TqxDMTAulAHz52IJCDA6shCig5EB0AZ0SUrmgaRkHgAun8gjZ/Umjtc4OWZzcri8FP9f/44Yh4kBkd0YNH8OfiEhRkcWQnQAMgDamE7xCYx5MYExgL30FDmZa8m7WEe+zcWxs5Vsee1PRDlMDOgVwuDvZWDr1t3oyEKIdqrFddDCewIjIhn1/L/yvVdfYMlPnmJap65EOkyU2BrZVH2O1/74Z5b/fCm7//0P1FVc+xk8QggjSR10C7XX6wC8zVldRe7bWRwtr7qqrC7C4Uf/EBvJ6TMIjo0zOqYQXmf0dQA3I3XQwiv8Ondh6NM/Zijgqqnl6PIVHC05T5G1keKGS+z423J3WV2QhZTZaYT0H2B0ZCE6pPZeBy0DoJ2zBAeR9KOnSMLdT5SXmcWR4+UU+TXxoauWjzJXucvqbCZSpk+m25AhRkcWwiv+/rc3OFNS6NFthkbHMf77i266Tl5eHm+99da3ddB//vOfr2oDLS8v5/nnn7+qDnrDhg28+uqrvP766xw4cMCjme+EDIAOxGyzkviD75OIu5+ocOUqcg+XUGTRfKLr2Ll+A71Wb6GfRZEydSw9R91rdGQh2j2pgxZtjtliIX7eXOJxD4OT777LoX15FJo0n5ka+GzrB4Ru+sRdVjdxJGHjJhgdWYgWudUzdW/x2TpopdS/A2mAAygA/klrXXWd9YqBy0Aj4LrdNyiEZ5gtFmKfeILYJ9zfn3zvPQ7tyqFQwS5zA7s+3kn3HbvpqzVJY1KInDrN2MBCtCPtuQ66paeBbgcGa62TgePAL26y7nit9RB58Dde1COPMO2VF/jp//oFT903hlEuGyYNX/k5eOurPfzhpaVsfGEpRe+8Q6PLZXRcIdq0b+qgk5OTuXDhwk3roFNSUkhNTf1OHfTcuXO/s93nnnuOiIiIb+ugPV0FDR48DVQp9RgwU2v9nZ+k+QhguNb63J1sU04DbV1nvvicnK2fku/SVPo1gIKQRitxLhg0OIa4J2dLWZ1oU4w+DVTqoP/hB8CqGyzTwAdKKQ38VWv9hgf3Kzwk9N4xPHjvGB4ELny9n4Mbt3OiscldVnfiOMG//A2xTsXA/n1ImDtHyuqEaOdueQSglNoBhF1n0Yta63eb13kRGA48rq+zQaVUH611uVIqFPfLRj/VWu+8wf4WAYsAoqKihpWUlNzJzyO84NKxIxxY8z4n7C7KrA6alCawyY8Yh2JgdHcGzp+HJTjI6JjCBxl9BGC0lh4BtPglIKWh45ZPAAAS7klEQVTU94AfAhO11vbbWP9loEZr/dqt1pWXgNqemqJCDq5cz4lLDk5ZnTSqJvybLEQ7TAzo04XB35uDX+cuRscUPkIGgIEvASmlpgDPAw/c6MFfKRUEmLTWl5u/ngT8qiX7FcYJjo1jzC9+5i6rKyvjUOYajl+oo9DmIu/CGbb8/v8Q1WAmoWcQSfPT8Q/tZXRkIcQNtPQ9gNcBG7C9+dzXL7XWP1RK9QHe1FpPBXoB65uXW4AsrfXWFu5XtAGB4eGMfO5ZRgIN586Su3wVx05fosTWSP7li2z7j78S2WAhoVsAyXNmEhgRaXRkIcQVWjQAtNb9bnB7OTC1+etCIKUl+xFtn61HT4b962KGAc5Llzi8LJNjpRcptjZRZK9m+//9f+6yumA/kjMeo1NcX6MjC+Hz5Jw+4XF+ISEMWfwjhgCuujqOLc/kaOEZiqxNlDhr+PDtFfRxWIkPsJDy2GS6JCUbHVkIj7udNtClS5fywgsvfOd2u93OrFmzKCgowGw2k5aWxquvvurxjDIAhFdZAgIYvGghg3GX1Z3IXsWRvFMUWjR/b6rl47Xv0Dv7ffpZFSlpD9J9mFwnKHzHjQYAwJIlSxg/fjwOh4OJEyeyZcsWHn74YY/uXwaAaDVmm5UB35/PANz9REVr1pKbU0iRRbOTBnZufI9e72ynrxlSHhpDr/vHGh1ZiJvyVh10YGAg48ePB8BqtZKamkppaanH88sHwgjDNbpclL7/Hod2H6HApLhoaQCgh9NGX6VJHjuM8EmTDU4p2qIrT4Os2lSAo7zWo9u39gmiS9qN368qLi4mNjaWzz777Ns66MTERJYsWfLtS0B9+vRh1KhRV9VBP/3008yYMeOmHwjzjaqqKlJTU9mxYwdxcVd/0FNbuhJYiLtitliInj6D6OnuetzSbVs59Ol+CoDdFge7v9hFt537iWvSJI0aTPSjjxobWIgreLMO2uVykZGRwdNPP/2dB39PkAEg2pyIyVOImDwFgNOffMLBHV9QoGGvn4O9+/fT+atc4ppgcEpfYp54QvqJBMBNn6l7kzfroBctWkR8fDzPPvvsXW/jZuRfjmjTej3wAJMeeACAc3u+4uD7H5HfpDng18DXR4/S6Ze/JdalGTQwin5zMmQYiFbnrTrol156ierqat58802vZZd/LaLd6HHPCCbeM4KJwMVDBzm4fhv5jkZyrU5yCgsI+tVviHEoEvv2ImHeHCwBAUZHFj7gmzrop556ivj4+JvWQWutmTp16nfqoFNTU696E7i0tJRXXnmFAQMGkJqaCsDixYtZuHChR7PLm8Ci3bt8Io+DqzdxvMZJmdVBo9IENPcTJUZ1Y+C8OfiFhBgdU3iB0V1AUgcthME6xSdw34sJ3AfYS0+Rk7mWvIv15NucHDtTie21PxHtMJEQFsLgBRnYunU3OrIQbYIcAYgOq/7MaQ4tX0ne2VpO2hpxqEb8tJmoBjP9uweSPG82Ab37GB1TtIDRRwBGkyMAIW7AP7QX9/zsGe4BnNVV5P4ti6MVVZRYmyiorWL7X94k0mEhPsRG8pwnCI6OMTqyEK1KBoDwCX6duzD0mR8zFHDV1HJk2QqOnjzvLqtruMyH//U24Q4r8UEWUmanEdJ/gNGRhfA6GQDC51iCg0j+8VMk4y6rO56VzZETlRRZmzjpquWjzFX0cVqJt5lIeXwKXZOkzFZ0TDIAhE+zBASQ+M8/IBF3JUV+9iqOHCmh0KL5WNfxydr1hGVvpq9FkTJ1LD1H3Wt0ZCE8RgaAEM3MFgsJ8+eSgHsYlGxYT+7+ExSaNJ+ZGvhs6weEbvqEviZImTiSsHETjI4s2jCpgxainTJbLMTNnEXcTPf3J997j0O7cihQsMvcwK6Pd9J9+276okm6byiRHq7pFb5B6qCFaAeiHnmEqEceAaBix3YOfryXAuArPwdf7d5N188PENekGXzPQKLS0qSSwkf4dB20Uupl4F+As803vaC13nyd9aYAfwTMuD8r+LaOZeQ6ANHWnfn8Uw5u+5x8l+a0XwMoCGm0EueCwcmxxM6aJcPAi648D37Lli1UVlZ6dPthYWE3fdYtddDwv7XWr91ooVLKDPwH8BBQCuxRSm3UWh/xwL6FMFTomPt5aMz9PASc37eXg5s+JL+xiYPWBg7k5RH8y98S64TE/uH0n5uB2WY1OrLwMKmDvrkRQH7zh8OjlFoJTAdkAIgOpfuw4UwYNpwJQNWRw+Ss28zxBheHbQ4OnSwi8JV/J8ahGBjbk4EL5klZnYd5+vXx2+XrddCLlVILgL3Az7TWF69ZHg6cuuL7UmCkB/YrRJvVJXEQYxMHMRa4XFhAzsoNHL/sIM/m5EhFGf6//h0xDhMDwrsy6HtzpayuHevQddBKqR1A2HUWvQj8J/A/Ad385++AH1y7iev83RuORKXUImARQFRU1K3iCdHmdYrry5gXfsYYwF5WxqHMNeRdsFNgc3Hs/Gk2/+6PRDeYSQgNJmlBBrYePY2OLO6A1EEDSqkY4D2t9eBrbh8NvKy1ntz8/S8AtNa/vtU25U1g0ZE1nDvLoWXZ5J2poeTbsjoTkQ0WEroFkjR3FoHh4UbHbNOMLoPz6TpopVRvrXVF87ePAde7F/YA8UqpWKAMSAfmtGS/QnQEth49Gf5vTzMcd1nd4WXZHCu7SLG1iUJ7FR+88RYRDj/6d7KSnD6DTnHGfOSh6Lha+h7Ab5VSQ3C/pFMMPAWglOqD+3TPqVprl1JqMbAN92mg/6W1PtzC/QrRofh17sKQn/6IIbjL6o6uyOJo8VmKrU2UOC7z4dsr3GV1gRaSn5hKl8RBRkcWQExMjGHP/j1BPg9AiDasscHB8cxsjhwvo8hPU2N2ojT0dtroZzUxZPpDdBuaanRMwxj9EpDR2sJ1AEIILzHbrAz8wfcYiLufqGjNGnJziii0aHZSx84NG+m1Zhv9LJAy+T5Cx9xvdORWp7X+zqmXvsATT97lCECIdqjR5eLkpk3k7jlKoUlx0dIAQE+njb4KUsYNp/eDDxmc0vuKioro1KkT3bt396khoLXm/PnzXL58mdjY2KuW3ckRgAwAITqAU1u2cOizrylAcd7PPQy6uWz0bdIkjU4iKi3N4ITe4XQ6KS0tpb6+3ugorc7f35+IiIjvXEMgA0AIH1bx0Yfk/P0rCprgTPMw6OKyEtcEg1PjiZ7xmPQTdWAyAIQQAJz98gsObt5JgUtT6deAVtCpuawuMTGafhlPyjDoYGQACCG+48KBA+S8u40TDU2U+znQShPU5EesUzGwbxgJczOkn6gDkAEghLipS8ePcXDNe5yocVJmddCoNAFNFmIcJgZGdSdxwTwswUFGxxR3QQaAEOK21ZQUk5O1jhOXGjhldeFSTdiaLEQ7TAzo3ZlB89OxdetudExxm2QACCHuSl1Fubus7lwtJ22NOFUjftpMVIOZhB5BJC9Ixz+0l9ExxU3IABBCtFjDhfPkLssmr/ISJdYmGkwuLNpEZIMf/bvYSMp4nODoGKNjimvIABBCeJTz0iV3P9HJCxRbm6gzuTBr5e4nCvYjZdYjhPQfYHRMgQwAIYQXuerqyFuRxZGC0xRbNbUmJ0or+jitxNtMpDw+ha5JKUbH9FkyAIQQraKxwUH+qlUcPnqSIovistmB0hDmtNHPqkh+eBw9R44yOqZPkQEghGh1jS4XxevWkXuwgEITVFscoCHUZaOvCYY8eC+9HnjA6JgdngwAIYThSjZu5NCXuRSaFBeay+q6O230U5qk+1OJmDzF4IQdkwwAIUSbUvbBNnJ27qNAK8419xN1/aaf6J6BRKWlSSWFh8gAEEK0Wac/3cnB7Z9T0AinLQ2gIKS5n2hwciyxs2bJMGgBGQBCiHbh3J6vyHn/I044/lFWF9w8DAYmRNA/Ix2zzWp0zHZFBoAQot2pOpTDwfXbOFHnotzqoElpApv8iHEoBsb2ZOCCeVJWdxtabQAopVYBCc3fdgGqtNZDrrNeMXAZaARctxtOBoAQvunyiTxyVm/ieI2TUquTRtWEf3NZ3YCIrgxaMBe/kBCjY7ZJhhwBKKV+B1RrrX91nWXFwHCt9bk72aYMACGEvfQUOZlrybtYxymbu6zOqs1EN5hJ6NWJpPnp2Hr0NDpmm9HqA0C5P4zzJDBBa33iOsuLkQEghGih+jOnObR8JXln3WV1jm/L6iz07xZA0txZBIaHGx3TUEYMgLHA72+0U6VUEXAR0MBftdZv3GRbi4BFAFFRUcNKSkpanE8I0fE4q6vIfTuLo+VV35bVmbWJSIcf8SFWUtIfIzg2zuiYrc6jA0AptQMIu86iF7XW7zav859Avtb6dzfYRh+tdblSKhTYDvxUa73zVuHkCEAIcTtcNbUcXb6CoyXnKbZq7CYnpm/K6gItDJk1jZABiUbHbBWtegSglLIAZcAwrXXpbaz/MlCjtX7tVuvKABBC3KnGBgd5mVkcPV5OoZ+m1uwuq+v9TVndow/RbWiq0TG9prUHwBTgF1rr65Z8KKWCAJPW+nLz19uBX2mtt95q2zIAhBAt0ehyUbhyFbmHSyiywKXmsrpeThv9LIqUqWPpOepeo2N6VGsPgL8BX2qt/3LFbX2AN7XWU5VSccD65kUWIEtr/crtbFsGgBDCUxpdLk6++y6H9uVRaIIqiwOAnk4bfRWkTBhB7wkTDU7ZcnIhmBBC3MKpze9z6PODFCjF+W/K6lw2+mpN0pgUIqdOMzjh3ZEBIIQQd6Bix3YOfryXAg1nm8vqujSX1SUNSyBq+vR2008kA0AIIe7SmS8+J2frp+S7NKeb+4lCGq3EumDwoGji0p9s08NABoAQQnjAha/3c3Djdk40NFHxbVmdH7FOxcD+fUiYO6fNldXJABBCCA+7dOwIB9a8zwm7i7Jry+qiuzNw/jwswUFGx5QBIIQQ3lRTVMjBles5ccnBqSvK6qIcJgb27sLg78/Br3MXQ7LJABBCiFZiLyvjUOYajl+o46TNhVM1YtVmohrMJPQMIml+Ov6hvVotjwwAIYQwQMO5s+QuX8Wx05coaS6rs2gTkQ0WEroGkDx3JoERkV7NIANACCEM5rx0icPLMjlWepFiaxP1zWV14Q4/+gf7kTI7jU7xCbfe0B2SASCEEG2Iq66OY8szOVp4hqIryur6OK3E+1tIeWwyXZKSPbIvGQBCCNFGNTY4OJG9iiN5pyi0QE1zP1GY00Y/qyJl2gR63DPirrcvA0AIIdqBRpeLojVryc0ppMgC1WYHNA+Df/75T+7qYy/vZAC03cvZhBCigzNbLPTLSKdfhnsYlL7/Hjm7j1DTpFvlM49lAAghRBtgtliInj6D6OkzWm2fplbbkxBCiDZFBoAQQvgoGQBCCOGjZAAIIYSPkgEghBA+SgaAEEL4KBkAQgjho2QACCGEj2rTVRBKqbNAyV3+9R7AOQ/Gac/kvria3B9Xk/vjHzrCfRGtte55Oyu26QHQEkqpvbfbh9HRyX1xNbk/rib3xz/42n0hLwEJIYSPkgEghBA+qiMPgDeMDtCGyH1xNbk/rib3xz/41H3RYd8DEEIIcXMd+QhACCHETXS4AaCUmqKUylNK5Sulfm50HiMppSKVUn9XSh1VSh1WSj1jdCajKaXMSqmvlVLvGZ3FaEqpLkqptUqpY82/I6ONzmQkpdS/Nv87yVVKZSul/I3O5G0dagAopczAfwAPA4lAhlIq0dhUhnIBP9NaDwRGAT/x8fsD4BngqNEh2og/Alu11gOAFHz4flFKhQNPA8O11oMBM5BubCrv61ADABgB5GutC7XWDmAlMN3gTIbRWldorfc3f30Z9z/wcGNTGUcpFQFMA940OovRlFIhwFjgLQCttUNrXWVsKsNZgACllAUIBMoNzuN1HW0AhAOnrvi+FB9+wLuSUioGGArsNjaJof4APAc0GR2kDYgDzgL/r/klsTeVUkFGhzKK1roMeA04CVQA1VrrD4xN5X0dbQCo69zm86c5KaWCgXXAs1rrS0bnMYJS6hHgjNZ6n9FZ2ggLkAr8p9Z6KFAL+Ox7ZkqprrhfLYgF+gBBSql5xqbyvo42AEqByCu+j8AHDuNuRinlh/vBP1Nr/Y7ReQw0BnhUKVWM+6XBCUqpFcZGMlQpUKq1/uaIcC3ugeCrHgSKtNZntdZO4B3gXoMzeV1HGwB7gHilVKxSyor7TZyNBmcyjFJK4X6N96jW+vdG5zGS1voXWusIrXUM7t+Lj7TWHf4Z3o1orSuBU0qphOabJgJHDIxktJPAKKVUYPO/m4n4wJviFqMDeJLW2qWUWgxsw/0u/n9prQ8bHMtIY4D5wCGl1IHm217QWm82MJNoO34KZDY/WSoE/sngPIbRWu9WSq0F9uM+e+5rfOCqYLkSWAghfFRHewlICCHEbZIBIIQQPkoGgBBC+CgZAEII4aNkAAghhI+SASCEED5KBoAQQvgoGQBCCOGj/j/wZv5O2+GERQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# we should see everything run twice\n",
+    "notebook.run_tag('Data')\n",
+    "notebook.run_tag('# Data')\n",
+    "print('-----data h1 done-----')\n",
+    "notebook.run_tag('Data 1')\n",
+    "notebook.run_tag('## Data 1')\n",
+    "print('-----data 1 h2 done-----')\n",
+    "notebook.run_tag('Data 2')\n",
+    "notebook.run_tag('## Data 2')\n",
+    "print('-----data 2 h2 done-----')\n",
+    "\n",
+    "notebook.run_tag('Plot')\n",
+    "notebook.run_tag('# Plot')\n",
+    "print('-----plot h1 done-----')\n",
+    "notebook.run_tag('Plot 1')\n",
+    "notebook.run_tag('## Plot 1')\n",
+    "print('-----plot 1 h2 done-----')\n",
+    "notebook.run_tag('Plot 2')\n",
+    "notebook.run_tag('## Plot 2')\n",
+    "print('-----plot 2 h2 done-----')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -88,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/tutorial/test.ipynb
+++ b/tutorial/test.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## This is a test notebook"
+    "# This is a test notebook"
    ]
   },
   {
@@ -21,8 +21,19 @@
     }
    ],
    "source": [
+    "# __init__\n",
     "a = 5\n",
     "print('I am inside loaded_notebook!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create_b\n",
+    "b = 10"
    ]
   },
   {
@@ -34,6 +45,217 @@
     "# add_one\n",
     "a += 1"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##block __init__\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('in __init__')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##lastblock\n",
+    "print('I should still be in __init__')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ran Data (heading 1)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(10)\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ran Data 1 (heading 2)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = -np.arange(10)\n",
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ran Data 2 (heading 2)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot\n",
+    "## Plot 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ran Plot 1 (heading 2)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1173b8278>]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAHe1JREFUeJzt3Xd8VfXhxvHPl4RAAiQQdoCQsElIEAjbLdaBKEitWje12P5q1V9bIYADKyqOWq11gfunrVUSpoBIHcWFAkJ2GGEkhBFWErKT+/39AW1RUS5wb84dz/svEm+Sx0PyvA4n9zzXWGsRERH/0cTpACIicnJU3CIifkbFLSLiZ1TcIiJ+RsUtIuJnVNwiIn5GxS0i4mdU3CIifkbFLSLiZ0K98UnbtWtn4+LivPGpRUQC0tq1a/dZa9u781ivFHdcXBxr1qzxxqcWEQlIxpjt7j5Wl0pERPyMiltExM+ouEVE/IyKW0TEz6i4RUT8jIpbRMTPqLhFRPyMiltExAO+3naAFz7Z0ihfyys34IiIBIvDNfU8tjyPN77YTmx0BDeO7E5EmHerVcUtInKKPs7fy4z5WRSXVnHL6Dj+8JO+Xi9tUHGLiJy0gxW1PPheDunrdtKrQ0vm/WoUQ7q3abSvr+IWEXGTtZZlWbu5b2EWhyrr+O35vbj9/F40Cw1p1BwqbhERN+wtq+behVm8n72HpC5RvDFpOAkxkY5kUXGLiPwIay3vri1i1pIcaupdTLukH784M57QEOeelKfiFhH5AYUHKpmWnsmnm/cxLD6a2Vcm0aN9S6djqbhFRL6rwWV5/fNtPP5+PiFNDLPGD+Dnw2Jp0sQ4HQ1QcYuIfMumPeVMTctg3Y5DnNu3PQ9PSCKmdbjTsb5FxS0iAtQ1uHjh4y088+FmWjQL4amrz+CKM2IwxjfOso+l4haRoJdZVMrd8zaQt7uccQNjuH9cAu1aNnM61g9ScYtI0Kqua+DPKzcy918FtG/VjLk3pnBhQkenY52QiltEgtKXBftJTctg2/5Krh3WjdRL+hMV3tTpWG5RcYtIUCmvrmP2sjzeWr2D2OgI/nbrcEb1aud0rJOi4haRoPFR3l6mz89kT1k1t54Zz+9+0qdRRqE8zf8Si4icpAMVtfxxcTYL1hfTp2NLnrtuFINiG28UytNU3CISsKy1LM7YxcxF2ZRX13HnBb35zXm9CAv179eQUXGLSEDaXVrNPQuyWJm7h4Fdo3j0p8Pp18mZUShPU3GLSECx1vL214U8/F4udS4XMy7tz6Qz4wnxkdvVPcGt4jbG/C9wK2CBTOAWa221N4OJiJys7fsrSE3L5IuC/YzoEc3sK5OJa9fC6Vged8LiNsZ0Ae4AEqy1VcaYd4BrgNe8nE1ExC0NLsurn23liRX5NG3ShEeuTOKaod188nZ1T3D3UkkoEG6MqQMigGLvRRIRcV/+7nKmpGWwofAQY/p3YNb4JDpFNXc6lledsLittTuNMU8AO4AqYIW1dsV3H2eMmQxMBoiNjfV0ThGRb6mtd/Hcx5t59qPNtGrelL9cO4hxyZ0D9iz7WO5cKmkDXAHEA4eAd40x11tr3zz2cdbaOcAcgJSUFOuFrCIiAKwvPMTUeRnk7ynnijNiuH9cItEtwpyO1WjcuVQyBthqrS0BMMakA6OAN3/0o0REPKyqtoEnP8jn5U+30qFVc16+KYUL+vv+KJSnuVPcO4ARxpgIjlwquQBY49VUIiLf8fmWfaSmZbLjQCXXDY9l6iX9iGzuH6NQnubONe7Vxph5wDqgHviGo5dERES8ray6jkeW5vH3r3YQ1zaCtyePYESPtk7HcpRbzyqx1t4P3O/lLCIi37IyZw8zFmRSUl7DbWf34K4xfQgPC3E6luN056SI+Jz9h2uYuTiHxRuK6depFXNvTCG5a2unY/kMFbeI+AxrLYs2FDNzUTaHa+r53YV9+NU5Pf1+FMrTVNwi4hOKD1Vxz4IsPszbyxndWvPYT5Pp07GV07F8kopbRBzlcln+/vUOHlmaR4PLcu9lCdw8Ki6gRqE8TcUtIo7Zuq+C1LQMVm89wOhebXlkQjKxbSOcjuXzVNwi0ujqG1y88tlW/rRiI2GhTXh0YhI/SwncUShPU3GLSKPK3VXG1LQMMopKuTChI7PGD6BjZGCPQnmailtEGkVNfQPPfriZ5z7eQuuIpjz788FcmtRJZ9mnQMUtIl63bsdBps7LYNPew1w5qAv3XpZAmyAahfI0FbeIeE1lbT1PvL+RVz/fSufI5rx6y1DO69vB6Vh+T8UtIl7x2eZ9pKZnUHigihtGdGfKxX1pFaSjUJ6m4hYRjyqtquPh93L5x5pC4tu14B+TRzA8yEehPE3FLSIesyJ7N/csyGJ/RS2/Oqcnd43pTfOmGoXyNBW3iJy2kvIaZi7O5r2MXfTvHMnLNw0lqWuU07EClopbRE6ZtZYF63fywOIcKmsauPuivkw+uwdNQzQK5U0qbhE5JTsPVTFjfiYf55cwOPbIKFSvDhqFagwqbhE5KS6X5a3V25m9LA+XhfvHJXDjSI1CNSYVt4i4raDkMKlpmXy17QBn9W7HwxOS6BatUajGpuIWkROqb3Axd9VW/rxyI81Dm/D4T5P56ZCuul3dISpuEflR2cWlTE3LIGtnGRcnduKP4xPp0EqjUE5ScYvIcVXXNfDMh5t44ZMC2kSE8fx1g7kkqbPTsQQVt4gcx9rtB5gyL4MtJRVMHNyVey/rT+sIjUL5ChW3iPxHRU09j7+fz+tfbCMmKpzXJw3jnD7tnY4l36HiFhEA/rWxhGnpmRSXVnHTyDjuvqgvLZqpInyR/lZEgtyhylpmvZfLvLVF9GjfgndvG0lKXLTTseRHqLhFgtiyzF3cuzCbg5W1/Oa8nvz2fI1C+QMVt0gQ2ltezf0Ls1mWtZvEmEhenzSUxBiNQvkLFbdIELHWMm9tEbPey6WqroGpF/fj1rPiNQrlZ1TcIkGi8EAl0+dnsmrTPobGtWH2xGR6tm/pdCw5BSpukQDnclne+GIbj72fjwEevCKR64Z3p4lGofyWilskgG3eW87UtEzWbj/IOX3a89CEAXRto1Eof6fiFglAdQ0u5vyrgKdXbiKiWQhP/mwgEwZ10ShUgFBxiwSYrJ2l3D0vg9xdZYxN7szMcYm0b9XM6VjiQSpukQBRXdfAUys3MXdVAdEtwnjxhiFclNjJ6VjiBW4VtzGmNfASMACwwCRr7RfeDCYi7vtq6wFS0zIo2FfB1SndmH5pf6IimjodS7zE3TPup4Hl1tqfGmPCAP12Q8QHlFfX8djyfP7vy+10iw7nzV8M58ze7ZyOJV52wuI2xkQCZwM3A1hra4Fa78YSkRP5KH8vM9Iz2VVWzaTR8fzhoj5EhOnqZzBw52+5B1ACvGqMGQisBe601lZ4NZmIHNfBiloeXJJD+jc76d2hJWm/HsXg2DZOx5JG5M59rqHAYOB5a+0goAJI/e6DjDGTjTFrjDFrSkpKPBxTRKy1LMkoZsyTn7BoQzF3nN+LJXecqdIOQu6ccRcBRdba1UffnsdxittaOweYA5CSkmI9llBE2FNWzb0LsliRs4fkrlG8eetw+neOdDqWOOSExW2t3W2MKTTG9LXW5gMXADnejyYi1lreWVPIrPdyqa13Mf3SfkwaHU+oRqGCmru/yfgt8NbRZ5QUALd4L5KIAOzYX8m0+Rl8tnk/w+OjeXRiMnHtWjgdS3yAW8VtrV0PpHg5i4gADS7La59v44n38wlpYnhowgCuHRqrUSj5Dz13SMSHbNxTzpR5GawvPMT5/Trw0IQBdI4KdzqW+BgVt4gPqK138cInW3jmw020bBbK09ecweUDYzQKJcel4hZx2IbCQ0xNyyBvdznjBsYwc1wCbVtqFEp+mIpbxCFVtQ08tXIjc1cV0L5VM+bemMKFCR2djiV+QMUt4oAvC/aTmpbBtv2VXDsslmmX9iOyuUahxD0qbpFGVF5dx+xleby1egfd20bwt18OZ1RPjULJyVFxizSSD/P2MGN+FnvKqvnlWfH87sK+hIeFOB1L/JCKW8TL9h+u4Y9Lcli4vpi+HVvx/PVDOKNba6djiR9TcYt4ibWWxRm7mLkom/LqOu4a05v/ObcXYaG6XV1Oj4pbxAt2l1Zzz4JMVubuZWC31jw2MZm+nVo5HUsChIpbxIOstbz9dSEPv5dLncvFPWP7c8voeEJ0u7p4kIpbxEO2768gNS2TLwr2M7JHW2ZPTKJ7W41CieepuEVOU4PL8upnW3liRT5NmzThkSuTuGZoN92uLl6j4hY5Dfm7y5mSlsGGwkOM6d+BWeOT6BTV3OlYEuBU3CKnoLbexbMfbea5jzcT2bwpz1w7iMuSO+ssWxqFilvkJK0vPMSUeRvYuOcw48+I4b5xiUS3CHM6lgQRFbeIm6pqG/jTinxe+WwrHSOb88rNKZzfT6NQ0vhU3CJu+HzLPlLTMtlxoJKfD49l2iX9aKVRKHGIilvkR5RV1/HI0lz+/lUhcW0jeHvyCEb0aOt0LAlyKm6RH7AyZw8zFmRSUl7DbWf34K4xfTQKJT5BxS3yHfsO1/DA4hwWbyimX6dWzL0xheSuGoUS36HiFjnKWsvC9cU8sDibipoGfn9hH247p6dGocTnqLhFgOJDVdyzIIsP8/YyKPbIKFTvjhqFEt+k4pag5nJZ/vbVDmYvy6PBZbnvsgRuGhWnUSjxaSpuCVpb91WQmpbB6q0HOLNXOx65Molu0RFOxxI5IRW3BJ36Bhcvf7qVJz/YSFhoEx6bmMxVKV11u7r4DRW3BJXcXWVMTcsgo6iUnyR05MHxA+gYqVEo8S8qbgkKNfUN/PXDzTz/8RZaRzTl2Z8P5tKkTjrLFr+k4paAt3b7QaamZbB572GuHNyFe8cm0EajUOLHVNwSsCpr63n8/Xxe+3wbnSOb8+otQzmvbwenY4mcNhW3BKRPN+0jNT2DooNV3DiyO1Mu7kfLZvp2l8Cg72QJKKWVdTy0NId31hTRo10L3rltJMPio52OJeJRKm4JGMuzdnPvwiwOVNTy63N7cucFvWneVKNQEnhU3OL3SsprmLkom/cyd5HQOZJXbx7KgC5RTscS8RoVt/gtay3p63byxyU5VNU2cPdFfZl8dg+ahmgUSgKb28VtjAkB1gA7rbWXeS+SyIntPFTF9PRMPtlYwpDubXh0YjK9OrR0OpZIoziZM+47gVwg0ktZRE7I5bK8uXo7jy7LwwIPXJ7IDSO600SjUBJE3CpuY0xXYCzwEPA7ryYS+QFbSg6TmpbB19sOclbvdjw8QaNQEpzcPeN+CpgCaKBYGl1dg4u5qwp4auUmwpuG8MRVA5k4uItuV5egdcLiNsZcBuy11q41xpz7I4+bDEwGiI2N9VhACW5ZO0uZmpZBdnEZlwzoxANXJNKhlUahJLi5c8Y9GrjcGHMp0ByINMa8aa29/tgHWWvnAHMAUlJSrMeTSlCprmvgmQ838cInBbSJCOP56wZzSVJnp2OJ+IQTFre1dhowDeDoGfcfvlvaIp60ZtsBpqRlUFBSwVVDujJjbH9aR2gUSuTf9Dxu8RmHa+p5fHkeb3y5nZiocN6YNIyz+7R3OpaIzzmp4rbWfgx87JUkEtQ+2VjC9PRMikuruGlkHHdf1JcWGoUSOS79ZIijDlXW8uCSXNLWFdGzfQvevW0kKXEahRL5MSpuccyyzF3cuzCbg5W13H5eL24/v5dGoUTcoOKWRre3rJr7FmazPHs3iTGRvD5pKIkxGoUScZeKWxqNtZZ31xYxa0kO1fUupl7cj1+eFU+oRqFEToqKWxpF4YFKps/PZNWmfQyLi2b2xCR6tNcolMipUHGLVzW4LG98sY3H38/HAA9ekch1wzUKJXI6VNziNZv3ljM1LZO12w9yTp/2PHxlEl1ahzsdS8TvqbjF4+oaXLz4yRb+8s/NRDQL4cmfDWTCII1CiXiKils8KrOolLvnbSBvdzljkzszc1wi7Vs1czqWSEBRcYtHVNc18NTKTcxdVUDbFmG8eMMQLkrs5HQskYCk4pbTtrpgP6npmWzdV8HVKd2YPrY/UeFNnY4lErBU3HLKyqvreGx5Pv/35Xa6RYfz1q3DGd2rndOxRAKeiltOyUf5e5mRnsmusmomjY7nDxf1ISJM304ijUE/aXJSDlTU8uCSHOZ/s5PeHVqS9utRDI5t43QskaCi4ha3WGt5L3MX9y/MprSqjjsu6M1vzutJs1CNQok0NhW3nNCesmruWZDFBzl7SO4axZu3Dqd/50inY4kELRW3/CBrLe+sKWTWe7nU1ruYfmk/Jo3WKJSI01Tcclw79leSmp7B51v2Mzw+mkcnJhPXroXTsUQEFbd8R4PL8trn23ji/XxCmhhmjR/Az4fFahRKxIeouOU/Nu4pZ8q8DNYXHuK8vu15aEISMRqFEvE5Km6htt7F8x9v4a8fbaJls1CevuYMLh8Yo1EoER+l4g5yGwoPMTUtg7zd5YwbGMPMcQm0balRKBFfpuIOUlW1Dfx55UZeWlVA+1bNmHtjChcmdHQ6loi4QcUdhL7Ysp9p6Rls21/JtcO6Me3S/kQ21yiUiL9QcQeRsuo6Zi/L42+rdxAbHcHfbh3OKI1CifgdFXeQ+GfuHmbMz2JveTW/PCue313Yl/Aw3a4u4o9U3AFu/+EaHlicw6INxfTt2IoXbhjCGd1aOx1LRE6DijtAWWtZtKGYBxbnUF5dx11jevM/5/YiLFS3q4v4OxV3ANpVWsU987P4Z95eBnZrzWMTk+nbqZXTsUTEQ1TcAcTlsrz9dSGPLM2lzuXinrH9uWV0PCG6XV0koKi4A8S2fRWkpmfwZcEBRvZoy+yJSXRvq1EokUCk4vZz9Q0uXvlsK39asZGwkCbMvjKJq4d20+3qIgFMxe3H8naXMXVeBhuKShnTvwOzxifRKaq507FExMtU3H6opr6BZz/awnMfbSYqvCnPXDuIy5I76yxbJEiouP3MNzsOMjUtg417DjP+jBjuG5dIdIswp2OJSCM6YXEbY7oBbwCdABcwx1r7tLeDybdV1tbzpxUbeeWzrXSKbM4rN6dwfj+NQokEI3fOuOuB31tr1xljWgFrjTEfWGtzvJxNjvp88z5S0zPZcaCS60fEMvXifrTSKJRI0DphcVtrdwG7jv653BiTC3QBVNxeVlpVxyNLc3n760Li2kbw9uQRjOjR1ulYIuKwk7rGbYyJAwYBq70RRv7rg5w93LMgk5LyGm47pwf/O6YPzZtqFEpETqK4jTEtgTTgLmtt2XH++2RgMkBsbKzHAgabfYdrmLkomyUZu+jXqRVzb0whuatGoUTkv9wqbmNMU46U9lvW2vTjPcZaOweYA5CSkmI9ljBIWGtZsH4nDyzOobKmgd9f2IfbzumpUSgR+R53nlVigJeBXGvtk96PFHyKD1UxY34mH+WXMCj2yChU744ahRKR43PnjHs0cAOQaYxZf/R90621S70XKzi4XJa3vtrBo8vyaHBZ7rssgZtGxWkUSkR+lDvPKvkUUJN4WEHJYVLTMvlq2wHO7NWOR65Molt0hNOxRMQP6M7JRlbf4OKlT7fy5w82EhbahMcmJnNVSlfdri4iblNxN6Kc4jKmpG0ga2cZP0noyIPjB9AxUqNQInJyVNyNoKa+gb9+uJnnP95C64imPHfdYC4Z0Eln2SJySlTcXrZ2+5FRqM17D3Pl4C7cOzaBNhqFEpHToOL2koqaep5Ykc9rn28jJiqc124Zyrl9OzgdS0QCgIrbC1ZtKmFaeiZFB6u4cWR3plzcj5bNdKhFxDPUJh5UWlnHQ0tzeGdNET3ateCd20YyLD7a6VgiEmBU3B6yPGs39y7M4kBFLb8+tyd3XtBbo1Ai4hUq7tO0t7yamYuyWZq5m4TOkbx681AGdIlyOpaIBDAV9ymy1pK+bid/XJJDVV0Dd1/Ul8ln96BpiEahRMS7VNynoOhgJdPnZ/GvjSUM6d6GRycm06tDS6djiUiQUHGfBJfL8ubq7Ty6LA8LPHB5IjeM6E4TjUKJSCNScbtpS8lhUtMy+HrbQc7q3Y6HJ2gUSkScoeI+gboGF3NXFfDUyk2ENw3hiasGMnFwF92uLiKOUXH/iKydpUxNyyC7uIxLkzox8/JEOrTSKJSIOEvFfRzVdQ385Z+bePFfBbSJCOOF6wdz8YDOTscSEQFU3N+zZtsBpqRlUFBSwVVDunLP2ASiIpo6HUtE5D9U3Ecdrqnn8eV5vPHldmKiwnlj0jDO7tPe6VgiIt+j4gY+2VjC9PRMikuruGlkHHdf1JcWGoUSER8V1O10qLKWB5fkkrauiJ7tWzDvVyMZ0l2jUCLi24K2uJdm7uK+hVkcqqzj9vN6cfv5vTQKJSJ+IeiKe29ZNfctzGZ59m4GdInk9UnDSIzRKJSI+I+gKW5rLe+uLWLWkhyq611MvbgfvzwrnlCNQomInwmK4i48UMn0+Zms2rSPYXHRzJ6YRI/2GoUSEf8U0MXd4LK88cU2Hn8/HwM8eEUi1w3XKJSI+LeALe7Ne8uZMi+DdTsOcW7f9jw0IYkurcOdjiUictoCrrjrGly8+MkW/vLPzUQ0C+HPVw9k/BkahRKRwBFQxZ1ZVMrd8zaQt7ucscmdeeDyRNq1bOZ0LBERjwqI4q6ua+CplZuYu6qAti3CePGGIVyU2MnpWCIiXuH3xb26YD+p6Zls3VfB1SndmD62P1HhGoUSkcDlt8VdXl3Ho8vzePPLHXSLDuetW4czulc7p2OJiHidXxb3R3l7mTE/k11l1fzizHh+/5M+RIT55f+KiMhJ86u2O1BRy4NLcpj/zU56d2hJ2q9HMTi2jdOxREQalV8Ut7WWJRm7mLkom9KqOu64oDe/Oa8nzUI1CiUiwcfni3tPWTUz5mexMncPyV2jePPW4fTvHOl0LBERx7hV3MaYi4GngRDgJWvtbK+m4shZ9j++LuShpbnU1ruYfmk/Jo3WKJSIyAmL2xgTAjwLXAgUAV8bYxZZa3O8FWrH/kpS0zP4fMt+hsdH8+jEZOLatfDWlxMR8SvunHEPAzZbawsAjDFvA1cAHi/uBpfl1c+28sSKfEKbNOGhCQO4dmisRqFERI7hTnF3AQqPebsIGO7pIKWVddz06lesLzzE+f068NCEAXSO0iiUiMh3uVPcxzvdtd97kDGTgckAsbGxJx0kMjyU7m0juGV0HJcPjNEolIjID3CnuIuAbse83RUo/u6DrLVzgDkAKSkp3yv2EzHG8PQ1g072w0REgo47T9H4GuhtjIk3xoQB1wCLvBtLRER+yAnPuK219caY24H3OfJ0wFestdleTyYiIsfl1vO4rbVLgaVeziIiIm7Q3SwiIn5GxS0i4mdU3CIifkbFLSLiZ1TcIiJ+xlh70vfKnPiTGlMCbD/FD28H7PNgHH+mY/FtOh7fpuPxX4FwLLpba9u780CvFPfpMMassdamOJ3DF+hYfJuOx7fpePxXsB0LXSoREfEzKm4RET/ji8U9x+kAPkTH4tt0PL5Nx+O/gupY+Nw1bhER+XG+eMYtIiI/wmeK2xhzsTEm3xiz2RiT6nQeJxljuhljPjLG5Bpjso0xdzqdyWnGmBBjzDfGmCVOZ3GaMaa1MWaeMSbv6PfISKczOckY879Hf06yjDF/N8Y0dzqTt/lEcR/zgsSXAAnAtcaYBGdTOaoe+L21tj8wAvhNkB8PgDuBXKdD+IingeXW2n7AQIL4uBhjugB3ACnW2gEcmZ6+xtlU3ucTxc0xL0hsra0F/v2CxEHJWrvLWrvu6J/LOfKD2cXZVM4xxnQFxgIvOZ3FacaYSOBs4GUAa22ttfaQs6kcFwqEG2NCgQiO8wpdgcZXivt4L0gctEV1LGNMHDAIWO1sEkc9BUwBXE4H8QE9gBLg1aOXjl4yxrRwOpRTrLU7gSeAHcAuoNRau8LZVN7nK8Xt1gsSBxtjTEsgDbjLWlvmdB4nGGMuA/Zaa9c6ncVHhAKDgeettYOACiBofydkjGnDkX+dxwMxQAtjzPXOpvI+Xylut16QOJgYY5pypLTfstamO53HQaOBy40x2zhyCe18Y8ybzkZyVBFQZK3997/A5nGkyIPVGGCrtbbEWlsHpAOjHM7kdb5S3HpB4mMYYwxHrmHmWmufdDqPk6y106y1Xa21cRz5vvjQWhvwZ1Q/xFq7Gyg0xvQ9+q4LgBwHIzltBzDCGBNx9OfmAoLgl7Vuveakt+kFib9nNHADkGmMWX/0fdOPvvanyG+Bt46e5BQAtzicxzHW2tXGmHnAOo48G+sbguAuSt05KSLiZ3zlUomIiLhJxS0i4mdU3CIifkbFLSLiZ1TcIiJ+RsUtIuJnVNwiIn5GxS0i4mf+H0KAYQcr7+uvAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(x, label='plot 1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ran Plot 2 (heading 2)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1174a1a90>]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xd0lGXixfHvM6nU0Dsh9N4jnWTVUBUQbCCLWABFauLaXVfX3dVVNzTBAjZsiIAgSEmwJKETeq/SWwAJveb5/QH+VlcxITPJO5m5n3M8hySTea9z4PLmnZmLsdYiIiK+w+V0ABER8SwVu4iIj1Gxi4j4GBW7iIiPUbGLiPgYFbuIiI9RsYuI+BgVu4iIj1Gxi4j4mEAnDlqiRAkbERHhxKFFRPKsFStWHLXWlszsdo4Ue0REBKmpqU4cWkQkzzLG7M7K7XQpRkTEx6jYRUR8jIpdRMTHqNhFRHyMil1ExMd4pNiNMR2NMVuMMduNMU974j5FRCR73C52Y0wAMBboBNQBehlj6rh7vyIikj2eOGNvBmy31u601l4EJgHdPHC/v7Fk5zHeW/AjVzL0z/mJiFyPJ4q9PLD3Fx/vu/a5XzHGDDDGpBpjUtPS0rJ1oG/WHuTlWRu56+1FbDt8KntpRUR8nCeK3fzO535zSm2tfddaG2mtjSxZMtN3xP6uv3ery8h7G7Hr6BluG72A0d9u4+LljGzdl4iIr/JEse8DKv7i4wrAAQ/c728YY7ijcXkS46LpUK8M8Ylb6frmAtbuO5EThxMRyZM8UezLgerGmMrGmGCgJ/C1B+73ukoUDGFMr8aMvz+Sn85e5I6xC3ll9ibOXbySk4cVEckT3C52a+1lYDAwD9gETLbWbnD3frOiXZ3SJMRGc+9NFXkneSedRiWzZOex3Di0iIjXMtbm/itMIiMjrafXHRdtP8rT09ax5/hZejcP5+lOtSgUGuTRY4iIOMkYs8JaG5nZ7XzmnaetqpVg3vAo+rWpzOfL9tB+RDLfbT7sdCwRkVznM8UOkC84gOdvr8PUga0oFBrIQx+mMnzSKo6fueh0NBGRXONTxf6zxuFFmTWkLcNurc436w4SE5/E12sO4MRlJxGR3OaTxQ4QHOgitl0NZg5pQ8Wi+Rj6+Sr6T0zlUPp5p6OJiOQony32n9UqU5hpj7Xm+dtqs2D7UdrFJ/H5sj06excRn+XzxQ4Q4DL0a1uFecOjqFc+jGemreO+8UvZfeyM09FERDzOL4r9Z5WKF+Cz/s15pUd91u9Pp8PIZCak7NSomIj4FL8qdrg6S9CrWTiJcdG0qVaCf3yziR5vLWLLIY2KiYhv8Lti/1mZsFDG3x/J6F6N2Xv8LLePSWFE4laNiolInue3xQ5Xz967NizH/LhobqtfllHfbuP2MSms3qtRMRHJu/y62H9WrEAwI3s25v0HIjl1/jI9xi3kH7M2alRMRPIkFfsv3FKrNAmxUfRqFs6EBT/SYWQyi3YcdTqWiMgNUbH/j0KhQfyze30mDWiBy8B945fyzLS1nDx/yeloIiJZomK/jhZVijNnWBSPRFXhi+V7aRefxPyNGhUTEe+nYv8D+YIDeKZzbaYPak3R/MH0m5jKkM9XcfT0BaejiYhcl4o9CxpUKMLXg9vweLsazFt/iHbxSUxftV+zBCLilVTsWRQc6GLIrdX5ZmgbIkoUYPgXq3n4o1QOnDjndDQRkV9Rsd+g6qULMeXRVrxwex0W7zhG+xHJfLJkNxmaJRARL6Fiz4YAl+GhNpWZNzyKhhXDeH76enqNX8KPRzUqJiLOU7G7Ibx4fj55uDmv3dmAjQdP0nFkMu8k7eDyFc0SiIhzVOxuMsZwz00VmR8XTXSNkrwyZzPdxy1i44GTTkcTET+lYveQ0oVDeadPU8be14SD6efo+uYC/pOwhQuXNUsgIrlLxe5Bxhhua1CWxNhoujYqx5jvtnPb6AWs2P2T09FExI+o2HNA0QLBxN/TiA8evImzFy5z19uLeGnmBs5evOx0NBHxAyr2HHRzzVIkxEXTp0UlPli4i/YjklmwTaNiIpKzVOw5rGBIIH/vVo/Jj7QkKMDFn99bypNT1pB+VqNiIpIzVOy5pFnlYswZ1paBf6rK1JX7iRmRxNz1h5yOJSI+SMWei0KDAniqYy1mDGpNyYIhPPrJCgZ9upK0UxoVExHPUbE7oF75MGYMbs0THWqSuPEwMfFJTF2xT6NiIuIRKnaHBAW4GHRzNWYPa0u1UgV5/Ms1PPDBcvZrVExE3KRid1i1UgX58pGWvNilDst3Had9fBITF+/SqJiIZJuK3Qu4XIYHWl8dFWtSqSgvzNjAve8uZkfaaaejiUgepGL3IhWL5WfiQ814/a4GbDl0ik6jUhj3w3YuaVRMRG6Ait3LGGO4O7Ii8x+P5paapXht7hbuGLuQ9fvTnY4mInmEit1LlSoUytt9mvJW7yYcPnmBbmMX8vq8zZy/pFExEfljbhW7MeZ1Y8xmY8xaY8xXxpgingomV3WqX5b5cVF0b1yesd/voPPoFFJ3HXc6loh4MXfP2BOBetbaBsBW4Bn3I8n/KpI/mDfubsjEh5px4VIGd7+zmBe/3sCZCxoVE5HfcqvYrbUJ1tqf22UJUMH9SHI9UTVKkhAbRd+WEXy0+OqoWNLWNKdjiYiX8eQ19oeAOdf7ojFmgDEm1RiTmpamMsquAiGBvNi1Ll8+0pKQIBd931/G45PXcOLsRaejiYiXMJm9jd0YMx8o8ztfes5aO+PabZ4DIoEeNgvvi4+MjLSpqanZiCu/dP7SFcZ8t423k3ZSNH8wL3erS6f6ZZ2OJSI5xBizwlobment3N0nMcb0BR4FbrXWns3K96jYPWvDgXSenLKWDQdO0rFuGf7erS6lCoc6HUtEPCyrxe7uq2I6Ak8BXbNa6uJ5dcuFMWNQa57qWIvvthwhJj6JL1P3alRMxE+5e439TaAQkGiMWW2MedsDmSQbAgNcDPxTVeYMa0vNMoV4Yspa7n9/GXuP6+9bEX/j9qWY7NClmJyVkWH5dOluXp2zGQs80aEm97eMIMBlnI4mIm7IlUsx4p1cLkOflhEkxEVzU0QxXpq5kXveWcz2I6ecjiYiuUDF7sPKF8nHhw/eRPw9DdmRdprOoxbw5nfbNCom4uNU7D7OGEOPJhVIjI2mXd3SvJGwla5valRMxJep2P1EyUIhjL2vCe/0acrR01dHxV6do1ExEV+kYvczHeqWYX5sNHc1qcDbSTvoNCqFpTuPOR1LRDxIxe6HwvIH8e+7GvDJw825nJHBve8u4a/T13Pq/CWno4mIB6jY/Vib6iWYNzyKh1pX5pOlu+kwIpnvtxxxOpaIuEnF7ufyBwfyQpc6TB3YigIhgTz4wXLivljNT2c0KiaSV6nYBYAm4UWZNbQNQ2+pxtdrDhATn8SstQc0SyCSB6nY5f+FBAYQ174mM4e0oXzRfAz+bBUDPl7B4ZPnnY4mIjdAxS6/UbtsYaYNbMWznWuRvDWNmPgkvli+R2fvInmEil1+V2CAiwFRVZk3PIo6ZQvz1NR19J6wlD3HNCom4u1U7PKHIkoU4PP+Lfhn93qs3ZdOh5HJvLfgR65k6OxdxFup2CVTLpehd/NKJMZF0bJqcV6etZE731rE1sMaFRPxRip2ybKyYfl4r28ko3o2Ys/xs9w2OoVR87dx8bJGxUS8iYpdbogxhm6NypMYG0WnemUZMX8rXcYsYM3eE05HE5FrVOySLcULhjC6V2Mm3B9J+rlLdB+3kH/N3sS5ixoVE3Gail3cElOnNAlxUfRsFs67yTvpNCqZxTs0KibiJBW7uK1waBD/6l6fz/o3xwK9xi/h2a/WcVKjYiKOULGLx7SqWoK5w6IYEFWFScv20D4+mW83HXY6lojfUbGLR+ULDuDZzrWZ9lhrwvIF8fBHqQz9fBXHTl9wOpqI31CxS45oVLEIM4e0ITamBnPWH6TdiGRmrN6vWQKRXKBilxwTHOhiWEx1Zg1pS8Vi+Rk2aTX9PkrlYPo5p6OJ+DQVu+S4mmUKMW1gK56/rTYLdxylfXwyny3dQ4ZmCURyhIpdckWAy9CvbRXmDY+iXvkwnv1qHfdNWMKuo2ecjibic1TskqsqFS/AZ/2b82qP+mzYf5KOo5IZn7xTo2IiHqRil1xnjKFns3AS46JpU60k/5y9iR7jFrLlkEbFRDxBxS6OKRMWyvj7mzKmV2P2/XSO28ekMCJxKxcua5ZAxB0qdnGUMYYuDcuRGBfN7Q3KMerbbXQZs4BVe35yOppInqViF69QrEAwI+5txPsPRHLq/GV6vLWIl2dt5OzFy05HE8lzVOziVW6pVZqE2Ch6Nw/nvQU/0nFkCou2H3U6lkieomIXr1MoNIh/3FGfSQNa4DJw34SlPD11LennNComkhUqdvFaLaoUZ+7wKB6JrsLk1L20H5FE4kaNiolkRsUuXi00KIBnOtVm+qDWFM0fTP+JqQz+bCVHNSomcl0eKXZjzF+MMdYYU8IT9yfyvxpUuDoq9ni7GiRsOEy7+CSmr9KomMjvcbvYjTEVgXbAHvfjiFxfUICLIbdW55uhbYgoUYDhX6zmoQ+Xc+CERsVEfskTZ+wjgCcBnTpJrqheuhBTHm3FC7fXYcnO47QfkczHS3ZrVEzkGreK3RjTFdhvrV3joTwiWRLgMjzUpjIJsVE0qliEv05fT8/xS/hRo2IimMyuURpj5gNlfudLzwHPAu2ttenGmF1ApLX2d190bIwZAAwACA8Pb7p79253cov8P2stX67Yx8uzNnLxcgax7WrQr01lAgP02gDxLcaYFdbayExvl90nn4wx9YFvgbPXPlUBOAA0s9Ye+qPvjYyMtKmpqdk6rsj1HD55nr9OX0/CxsPULx/Gv+9sQJ1yhZ2OJeIxWS32bJ/SWGvXWWtLWWsjrLURwD6gSWalLpJTShcO5Z0+TRnXuwkH08/R9c0F/Cdhi0bFxO/oZ1XxKcYYOtcvS2JsNF0blWPMd9u5bfQCVuzWqJj4D48V+7Uzd416iFcoWiCY+Hsa8eGDN3Hu4hXuensRL83cwJkLGhUT36czdvFpf6pZinmxUfRpUYkPFu6iw8hkUralOR1LJEep2MXnFQwJ5O/d6jH5kZYEB7jo894ynpyyhvSzGhUT36RiF7/RrHIxZg9ry2N/qsrUlfuJGZHE3PV6rl98j4pd/EpoUABPdqzFjEGtKVkwhEc/WcGgT1eSdkqjYuI7VOzil+qVD2PG4NY80aEmiZsOExOfxNQV+zQqJj5BxS5+KyjAxaCbqzF7aFuqlSrI41+uoe8Hy9n309nMv1nEi6nYxe9VK1WQLx9pyUtd65K66zgdRiQzcfEujYpJnqViFwFcLkPfVhHMGx5Fk0pFeWHGBu59dzE70k47HU3khqnYRX6hYrH8THyoGW/c3ZCth0/TaVQK437YzqUrGU5HE8kyFbvI/zDGcFfTCiTGRRFTuxSvzd3CHWMXsn5/utPRRLJExS5yHaUKhTKud1Pe/nMTDp+8QLexC3lt7mbOX9KomHg3FbtIJjrWK8u3cdH0aFyecT/soPPoFFJ3HXc6lsh1qdhFsiAsfxCv392QiQ8148KlDO5+ZzF/m7Ge0xoVEy+kYhe5AVE1SpIQG0XflhFMXLKbDiOSSdqqUTHxLip2kRtUICSQF7vWZcqjLQkNctH3/WU8PnkNJ85edDqaCKBiF8m2ppWK8c3Qtgy+uRozVu8nJj6ZOesOOh1LRMUu4o7QoAD+0qEmMwa3pkxYCAM/XcmjH6/gyMnzTkcTP6ZiF/GAuuXCmP5Ya57qWIvvthwhJj6Jyal7NSomjlCxi3hIYICLgX+qytxhbalVpjBPTlnL/e8vY+9xjYpJ7lKxi3hYlZIFmTSgBS93q8vK3T/RYWQyHyz8kSsaFZNcomIXyQEul6FPywgS4qJpVrkYL83cyN1vL2L7kVNORxM/oGIXyUHli+TjgwduYsS9Ddl59AydRy3gze+2aVRMcpSKXSSHGWPo3rgC8+OiaVe3NG8kbKXLmAWs26dRMckZKnaRXFKiYAhj72vCO32acvzMRe4Yt5BX5mzSqJh4nIpdJJd1qFuGxLho7mpSgXeSdtJpVApLdx5zOpb4EBW7iAPC8gXx77sa8Gm/5lzOyODed5fw/PR1nDp/yelo4gNU7CIOal2tBPOGR/FQ68p8unQPHUYk8/3mI07HkjxOxS7isPzBgbzQpQ5TB7aiQEggD364nNgvVnP8jEbFJHtU7CJeokl4UWYNbcPQW6szc80B2sUnMXPNAc0SyA1TsYt4kZDAAOLa1WDmkDaUL5qPIZ+vov/EFRzWqJjcABW7iBeqXbYw0wa24tnOtUjZlkZMfBKTlu3R2btkiYpdxEsFBrgYEFWVecOjqFO2ME9PW0fvCUvZc0yjYvLHVOwiXi6iRAE+79+Cf3avx9p96bQfmcSElJ0aFZPrUrGL5AEul6F380okxkXRqmoJ/vHNJu58axFbD2tUTH5LxS6Sh5QNy8d7fSMZ1bMRu4+d4bbRKYyav42LlzUqJv/ldrEbY4YYY7YYYzYYY17zRCgRuT5jDN0alWd+XDQd65VlxPyro2Jr9p5wOpp4CbeK3RhzM9ANaGCtrQu84ZFUIpKp4gVDGNOrMePvj+TEuYt0H7eQf36zkXMXNSrm79w9Yx8IvGqtvQBgrdV7oUVyWbs6pUmMi+bem8IZn/IjHUcls3iHRsX8mbvFXgNoa4xZaoxJMsbc5IlQInJjCocG8UqP+nzWvzkAvcYv4Zlp6zipUTG/lGmxG2PmG2PW/85/3YBAoCjQAngCmGyMMde5nwHGmFRjTGpaWppH/ydE5KpWVUswd1gU/dpU5ovle2gfn8y3mw47HUtymXHnnWzGmLlcvRTzw7WPdwAtrLV/2NyRkZE2NTU128cVkcyt3nuCp6asZcvhU3RtWI6/dalD8YIhTscSNxhjVlhrIzO7nbuXYqYDt1w7YA0gGDjq5n2KiAc0qliEmUPaMDymOnPWHyQmPokZq/drlsAPuFvs7wNVjDHrgUlAX6vfNSJeIzjQxfCYGswa0pbw4gUYNmk1/T5K5WD6OaejSQ5y61JMdulSjEjuu5Jh+WDhj7yRsIVAl4tnOtei103huFy/+7SYeKHcuhQjInlEgMvQr20V5g2Pon75MJ77aj33TVjCrqNnnI4mHqZiF/EzlYoX4LP+zXm1R3027D9Jh5HJvJu8g8tXNEvgK1TsIn7IGEPPZuEkxkXTtnpJ/jV7M3e+tYjNh046HU08QMUu4sfKhIUy/v6mjOnVmH0/neP20QuIT9zKhcuaJcjLVOwifs4YQ5eG5UiMi6ZLw3KM/nYbt49ewMo9PzkdTbJJxS4iABQrEMyIexvx/gORnL5wmTvfWsTLszZy9uJlp6PJDVKxi8iv3FKrNAmxUfRuHs57C36kw8hkFm7X+w7zEhW7iPxGodAg/nFHfb4Y0IJAl4veE5by9NS1pJ/TqFheoGIXketqXqU4c4a15ZHoKkxO3Uu7+CQSNhxyOpZkQsUuIn8oNCiAZzrVZvqg1hQrEMyAj1cw6LOVpJ264HQ0uQ4Vu4hkSYMKV0fF/tK+BokbDtNuRBJfrdqnUTEvpGIXkSwLCnAx+JbqzB7WhiolChD7xRoe/HA5+09oVMybqNhF5IZVK1WILx9txd+61GHpzuO0j0/i4yW7ycjQ2bs3ULGLSLYEuAwPtq5MQmwUjcOL8tfp6+n57hJ2pp12OprfU7GLiFsqFsvPxw8347W7GrD50Ek6jkrhrR80KuYkFbuIuM0Ywz2RFZkfF83NNUvy77mbuWPcQjYe0KiYE1TsIuIxpQqH8k6fSN7q3YRD6Rfo+uYC3pi3hfOXNCqWm1TsIuJxneqXZX5cFN0alefN77dz2+gUVuw+7nQsv6FiF5EcUSR/MP+5pyEfPdSM85cyuOvtxbz49QbOXNCoWE5TsYtIjoquUZJ5sVHc36ISHy3eRYeRyaRsS3M6lk9TsYtIjisYEshL3eox+ZGWBAe66PPeMp74cg3pZzUqlhNU7CKSa26KKMbsoW157E9VmbZqPzEjkpi7/qDTsXyOil1EclVoUABPdqzFjEGtKVkwhEc/WcnAT1Zw5NR5p6P5DBW7iDiiXvkwZgxuzRMdavLt5iO0i09mygqNinmCil1EHBMU4GLQzdWYPbQt1UsV5C9frqHvB8vZ99NZp6PlaSp2EXFctVIFmfxIS17qWpfUXcdpPyKZjxbt0qhYNqnYRcQruFyGvq0iSIiNIjKiGH/7egP3vLOYHRoVu2EqdhHxKhWK5uejB2/iP3c3ZNuR03QalcLY77dzSaNiWaZiFxGvY4zhzqYVmB8XTUztUrw+bwvd3lzI+v3pTkfLE1TsIuK1ShYKYVzvprz95yaknb5At7EL+ffczRoVy4SKXUS8Xsd6ZZkfG02PxuV564cddB6VwvJdGhW7HhW7iOQJYfmDeP3uhnz8cDMuXsng7rcX88KM9ZzWqNhvqNhFJE9pW70k84ZH8UCrCD5espsOI5JJ2qpRsV9SsYtInlMgJJAXu9ZlyqMtCQ1y0ff9ZcRNXs2JsxedjuYVVOwikmc1rVSMb4a2Zcgt1fh69QFi4pOYvU6jYm4VuzGmkTFmiTFmtTEm1RjTzFPBRESyIjQogMfb1+TrwW0oG5aPxz5dyaMfr+DISf8dFXP3jP014CVrbSPghWsfi4jkujrlCvPVY614ulMtvt9yhJj4JCan7vXLUTF3i90Cha/9Ogw44Ob9iYhkW2CAi0ejqzJnWFtqlSnMk1PW0ue9Zew97l+jYsadv82MMbWBeYDh6l8Sray1uzP7vsjISJuamprt44qIZCYjw/Lpsj28OnsTGRae6FCTvq0iCHAZp6NlmzFmhbU2MtPbZVbsxpj5QJnf+dJzwK1AkrV2qjHmHmCAtTbmOvczABgAEB4e3nT37kz7X0TEbftPnOO5r9bxw5Y0moQX4bW7GlCtVCGnY2WLx4o9k4OkA0WstdYYY4B0a23hzL5PZ+wikpustUxfvZ+XZm7k7IUrDL21Go9EVyUoIG+9MDCrxe7u/9UBIPrar28Btrl5fyIiHmeMoXvjq6Ni7euW5o2ErXQZs4B1+3xzVMzdYu8P/McYswb4F9cutYiIeKMSBUN4874mvNunKcfPXKTb2AW8MmeTz42KuXUpJrt0KUZEnJZ+7hKvzN7EpOV7qVyiAK/2qE/zKsWdjvWHcutSjIhInhSWL4hX72zAp/2aczkjg3vfXcLz09dx6vwlp6O5TcUuIn6tdbUSzBseRb82lfls6R46jEjm+81HnI7lFhW7iPi9/MGBPH97HaYObEWBkEAe/HA5sV+s5viZvDkqpmIXEbmmcXhRZg1tw7BbqzNzzQHaxScxc82BPDdLoGIXEfmFkMAAYtvVYNbQNpQvmo8hn6+i/8QVHM5Do2IqdhGR31GrTGGmDWzFc51rk7ItjZj4JCYt25Mnzt5V7CIi1xEY4KJ/VBXmDY+ibrnCPD1tHb0nLGXPMe8eFVOxi4hkIqJEAT7r14J/da/Pun3ptB+ZxISUnVzJ8M6zdxW7iEgWuFyG+5qHkxAXReuqJfjHN5vo8dYithw65XS031Cxi4jcgLJh+ZjQN5JRPRux9/hZbh+Twsj5W7l4OcPpaP9PxS4icoOMMXRrVJ7E2Cg61y/LyPnb6DJmAWv2nnA6GqBiFxHJtuIFQxjVszHv9Y0k/dwluo9byD+/2ci5i86OiqnYRUTcdGvt0iTERdGzWTjjU36kw8hkFu046lgeFbuIiAcUDg3iX93r83n/FhgD941fyjPT1nHSgVExFbuIiAe1rFqcucOiGBBVhS+W76FdfBLzNx7O1QwqdhERD8sXHMCznWvz1WOtKZo/mH4TUxn6+SqOnb6QK8dXsYuI5JCGFYvw9eA2xLWrwZz1B4mJT2LxjmM5flwVu4hIDgoOdDH01up8M7Qt9cqHEVEif44fMzDHjyAiItQoXYiPH26eK8fSGbuIiI9RsYuI+BgVu4iIj1Gxi4j4GBW7iIiPUbGLiPgYFbuIiI9RsYuI+BjjxL+4bYxJA3Zn89tLAM7tYXofPR7/pcfi1/R4/JovPB6VrLUlM7uRI8XuDmNMqrU20ukc3kKPx3/psfg1PR6/5k+Phy7FiIj4GBW7iIiPyYvF/q7TAbyMHo//0mPxa3o8fs1vHo88d41dRET+WF48YxcRkT+Qp4rdGNPRGLPFGLPdGPO003mcYoypaIz53hizyRizwRgzzOlM3sAYE2CMWWWMmeV0FqcZY4oYY6YYYzZf+33S0ulMTjHGxF77c7LeGPO5MSbU6Uw5Lc8UuzEmABgLdALqAL2MMXWcTeWYy8Dj1traQAtgkB8/Fr80DNjkdAgvMQqYa62tBTTETx8XY0x5YCgQaa2tBwQAPZ1NlfPyTLEDzYDt1tqd1tqLwCSgm8OZHGGtPWitXXnt16e4+oe2vLOpnGWMqQDcBkxwOovTjDGFgSjgPQBr7UVr7QlnUzkqEMhnjAkE8gMHHM6T4/JSsZcH9v7i4334eZkBGGMigMbAUmeTOG4k8CSQ4XQQL1AFSAM+uHZpaoIxpoDToZxgrd0PvAHsAQ4C6dbaBGdT5by8VOzmdz7n1y/pMcYUBKYCw621J53O4xRjzO3AEWvtCqezeIlAoAnwlrW2MXAG8MvnpIwxRbn6k31loBxQwBjzZ2dT5by8VOz7gIq/+LgCfvAj1fUYY4K4WuqfWmunOZ3HYa2BrsaYXVy9RHeLMeYTZyM5ah+wz1r7809xU7ha9P4oBvjRWptmrb0ETANaOZwpx+WlYl8OVDfGVDbGBHP1CZCvHc7kCGOM4er1003W2nin8zjNWvuMtbaCtTaCq78vvrPW+vxZ2fVYaw8Be40xNa996lZgo4ORnLQHaGGMyX/tz82t+METyYFOB8gqa+1lY8xgYB5Xn9l+31q7weFYTmkN9AHWGWNWX/vcs9ba2Q5mEu8yBPj02knQTuBBh/M4wlq71BgzBVjJ1VeTrcIP3oGqd56KiPiYvHQpRkREskDFLiLiY1TsIiI+RsUuIuJjVOwiIj5bsgl2AAAAF0lEQVRGxS4i4mNU7CIiPkbFLiLiY/4PKwlE2koD/akAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(y, label='plot 2')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -52,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is in reference to issue #1 

I added markdown headings as tags, and they work in a nested fashion.

# Markdown
So if your notebook that you're loading looks like this

----
## Run this full section
```python
print('full section')
```
### Run only the first part
```python
print('first part')
```

### Run only the second part
```python
print('second part')
```
## Next part
```python
print("This won't get run when you call 'Run this full section'"
```

----

Then you can do:
```python
notebook = Notebook(file)
notebook.run_tag('Run this full section') # or '## Run this full section'
notebook.run_tag('Run only the first part') # or '### Run only the first part'
notebook.run_tag('Run only the second part') # or '### Run only the second part'

```

# Blocks
I also added block style tags as discussed. I couldn't decide if I should make them nested so that it works the same as markdown, but I figured it would get too convoluted and I'd rather have the blocks close implicitly. 

```python
##block some_name
...
```
```python
... # has the some_name tag
```
```python
##block some_other_name
... # (some_name was implicitly closed)
```
```python
##lastblock
... # has the some_other_name tag
```
```python
... # doesn't have a tag
```

I also cleaned up some of the code a bit, hope you don't mind.